### PR TITLE
Fixes NPE in JavadocLikePackageFilter when matching against classes in the default (empty) package

### DIFF
--- a/japicmp/src/main/java/japicmp/filter/JavadocLikePackageFilter.java
+++ b/japicmp/src/main/java/japicmp/filter/JavadocLikePackageFilter.java
@@ -26,6 +26,7 @@ public class JavadocLikePackageFilter implements ClassFilter {
     @Override
     public boolean matches(CtClass ctClass) {
         String name = ctClass.getPackageName();
+        name = name == null ? "" : name;
         return pattern.matcher(name).matches();
     }
 }

--- a/japicmp/src/test/java/japicmp/filter/PackageFilterTest.java
+++ b/japicmp/src/test/java/japicmp/filter/PackageFilterTest.java
@@ -54,7 +54,14 @@ public class PackageFilterTest {
         assertThat(pf.matches(createCtClassForPackage("de.test.package.packageOne.test2")), is(true));
     }
 
+    @Test
+    public void testMatchAgainstDefaultPackage() {
+        JavadocLikePackageFilter pf = new JavadocLikePackageFilter("foo");
+        assertThat(pf.matches(createCtClassForPackage("")), is(false));
+    }
+
     private CtClass createCtClassForPackage(String packageName) {
-        return CtClassBuilder.create().name(packageName + ".Test").addToClassPool(new ClassPool());
+        String className = packageName + (packageName.isEmpty() ? "" : ".") + "Test";
+        return CtClassBuilder.create().name(className).addToClassPool(new ClassPool());
     }
 }


### PR DESCRIPTION
Without this patch I get an NPE like this:

```
Execution of JApiCmp failed: null
java.lang.NullPointerException
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
	at java.util.regex.Matcher.reset(Matcher.java:309)
	at java.util.regex.Matcher.<init>(Matcher.java:229)
	at java.util.regex.Pattern.matcher(Pattern.java:1093)
	at japicmp.filter.JavadocLikePackageFilter.matches(JavadocLikePackageFilter.java:29)
	at japicmp.filter.Filters.includeClass(Filters.java:63)
	at japicmp.cmp.JarArchiveComparator.applyFilter(JarArchiveComparator.java:190)
	at japicmp.cmp.JarArchiveComparator.compareClassLists(JarArchiveComparator.java:171)
	at japicmp.cmp.JarArchiveComparator.createAndCompareClassLists(JarArchiveComparator.java:153)
	at japicmp.cmp.JarArchiveComparator.compare(JarArchiveComparator.java:67)
	at japicmp.cli.JApiCli$Compare.run(JApiCli.java:77)
	at japicmp.JApiCmp.main(JApiCmp.java:16)
```

when invoking `japicmp` with an include pattern and the JAR files contain classes in the default package.