### PR TITLE
Change maven site report name and description

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
@@ -133,7 +133,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 			.append(" compatibility of");
 		appendList(sb, options.getNewArchives());
 		sb.append(" against");
-		appendList(sb, options.getNewArchives());
+		appendList(sb, options.getOldArchives());
 		return sb.toString();
 	}
 

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
@@ -1,6 +1,8 @@
 package japicmp.maven;
 
 import com.google.common.base.Optional;
+
+import japicmp.config.Options;
 import japicmp.output.xml.XmlOutput;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
@@ -8,6 +10,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -58,13 +61,14 @@ public class JApiCmpReport extends AbstractMavenReport {
 	private String versionRangeWithProjectVersion;
 	@Component
 	private ArtifactMetadataSource metadataSource;
+	private JApiCmpMojo mojo;
+	private MavenParameters mavenParameters;
+	private PluginParameters pluginParameters;
 
 	@Override
 	protected void executeReport(Locale locale) throws MavenReportException {
 		try {
-			JApiCmpMojo mojo = new JApiCmpMojo();
-			MavenParameters mavenParameters = new MavenParameters(artifactRepositories, artifactFactory, localRepository, artifactResolver, mavenProject, mojoExecution, versionRangeWithProjectVersion, metadataSource);
-			PluginParameters pluginParameters = new PluginParameters(skip, newVersion, oldVersion, parameter, dependencies, Optional.<File>absent(), Optional.of(outputDirectory), false, oldVersions, newVersions, oldClassPathDependencies, newClassPathDependencies);
+			JApiCmpMojo mojo = getMojo();
 			Optional<XmlOutput> xmlOutputOptional = mojo.executeWithParameters(pluginParameters, mavenParameters);
 			if (xmlOutputOptional.isPresent()) {
 				XmlOutput xmlOutput = xmlOutputOptional.get();
@@ -90,18 +94,54 @@ public class JApiCmpReport extends AbstractMavenReport {
 		}
 	}
 
+	JApiCmpMojo getMojo() throws MojoFailureException {
+		if (mojo != null) {
+			return mojo;
+		}
+		mojo = new JApiCmpMojo();
+		mavenParameters = new MavenParameters(artifactRepositories, artifactFactory, localRepository, artifactResolver, mavenProject, mojoExecution, versionRangeWithProjectVersion, metadataSource);
+		pluginParameters = new PluginParameters(skip, newVersion, oldVersion, parameter, dependencies, Optional.<File>absent(), Optional.of(outputDirectory), false, oldVersions, newVersions, oldClassPathDependencies, newClassPathDependencies);
+		return mojo;
+	}
+
+	Options getOptions() {
+		try {
+			return getMojo().getOptions(pluginParameters, mavenParameters);
+		} catch (MojoFailureException ignore) {
+			return null;
+		}
+	}
+
 	@Override
 	public String getOutputName() {
-		return "japicmp-maven-plugin-report";
+		return "japicmp";
 	}
 
 	@Override
 	public String getName(Locale locale) {
-		return "japicmp-maven-plugin";
+		return "japicmp";
 	}
 
 	@Override
 	public String getDescription(Locale locale) {
-		return "japicmp is a maven plugin that computes the differences between two versions of a jar file/artifact.";
+		Options options = getOptions();
+		if (options == null) {
+			return "failed report";
+		}
+		StringBuilder sb = new StringBuilder()
+			.append(options.isOutputOnlyBinaryIncompatibleModifications() ?"Binary" :"Source")
+			.append(" compatibility of");
+		appendList(sb, options.getNewArchives());
+		sb.append(" against");
+		appendList(sb, options.getNewArchives());
+		return sb.toString();
+	}
+
+	private void appendList(StringBuilder sb, List<File> archives) {
+		char sep = ' ';
+		for(File archive : archives) {
+			sb.append(sep).append(archive.getName());
+			sep = ';';
+		}
 	}
 }

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -9,7 +9,23 @@
 
 	<artifactId>japicmp-test-maven-plugin</artifactId>
 
+	<properties>
+		<!-- minimize standard reports -->
+		<mpir.skip>true</mpir.skip>
+	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+			<version>6.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+			<version>3.4</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.github.siom79.japicmp</groupId>
 			<artifactId>japicmp-maven-plugin</artifactId>
@@ -241,6 +257,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- run site plugin to build reports during 'pre-integration-test' phase
+			this allows integrations tests to verify site report generation -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>build-site-to-test</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>site</goal>
+						</goals>
+						<configuration>
+							<skip>false</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
@@ -257,4 +291,29 @@
 			</plugin>
 		</plugins>
 	</build>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>${project.version}</version>
+				<configuration>
+					<oldVersion>
+						<dependency>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp-test-v1</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</oldVersion>
+					<newVersion>
+						<dependency>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp-test-v2</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</newVersion>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -286,6 +286,11 @@
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+						<configuration>
+							<systemPropertyVariables>
+								<project.version>${project.version}</project.version>
+							</systemPropertyVariables>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/japicmp-testbase/japicmp-test-maven-plugin/src/test/java/japicmp/test/ITReportTitle.java
+++ b/japicmp-testbase/japicmp-test-maven-plugin/src/test/java/japicmp/test/ITReportTitle.java
@@ -1,18 +1,17 @@
 package japicmp.test;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.select.Elements;
-import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.Test;
 
 public class ITReportTitle {
 
@@ -20,7 +19,7 @@ public class ITReportTitle {
 	public void testReportTitle() throws IOException {
 		Path htmlPath = Paths.get(System.getProperty("user.dir"), "target", "site", "project-reports.html");
 		assertThat(Files.exists(htmlPath), is(true));
-		Document document = Jsoup.parse(htmlPath.toFile(), Charset.forName("UTF-8").toString());
+		Document document = Jsoup.parse(htmlPath.toFile(), "UTF-8");
 
 		Elements leftNav = document.select("#leftColumn [href=\"japicmp.html\"]");
 		assertThat(leftNav.attr("title"), is("japicmp"));
@@ -31,6 +30,8 @@ public class ITReportTitle {
 		assertThat(link.text(), is("japicmp"));
 
 		Elements description = overviewRow.select("td:eq(1)");
-		assertThat(description.text(), is("Source compatibility of japicmp-test-v2-0.8.2-SNAPSHOT.jar against japicmp-test-v2-0.8.2-SNAPSHOT.jar"));
+    String projectVersion = System.getProperty("project.version");
+		assertThat(description.text(), is("Source compatibility of japicmp-test-v2-"+projectVersion
+		    + ".jar against japicmp-test-v1-"+ projectVersion + ".jar"));
 	}
 }

--- a/japicmp-testbase/japicmp-test-maven-plugin/src/test/java/japicmp/test/ITReportTitle.java
+++ b/japicmp-testbase/japicmp-test-maven-plugin/src/test/java/japicmp/test/ITReportTitle.java
@@ -1,0 +1,36 @@
+package japicmp.test;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ITReportTitle {
+
+	@Test
+	public void testReportTitle() throws IOException {
+		Path htmlPath = Paths.get(System.getProperty("user.dir"), "target", "site", "project-reports.html");
+		assertThat(Files.exists(htmlPath), is(true));
+		Document document = Jsoup.parse(htmlPath.toFile(), Charset.forName("UTF-8").toString());
+
+		Elements leftNav = document.select("#leftColumn [href=\"japicmp.html\"]");
+		assertThat(leftNav.attr("title"), is("japicmp"));
+		assertThat(leftNav.text(), is("japicmp"));
+
+		Elements overviewRow = document.select("#bodyColumn tr:has([href=\"japicmp.html\"])");
+		Elements link = overviewRow.select("[href=\"japicmp.html\"]");
+		assertThat(link.text(), is("japicmp"));
+
+		Elements description = overviewRow.select("td:eq(1)");
+		assertThat(description.text(), is("Source compatibility of japicmp-test-v2-0.8.2-SNAPSHOT.jar against japicmp-test-v2-0.8.2-SNAPSHOT.jar"));
+	}
+}


### PR DESCRIPTION
Change the maven site japicmp report to be more descriptive.  The report name is more consistent with other reports like PMD, Findbugs, and Checkstyle.  The report description includes the old and new versions.