### PR TITLE
Add further tests to cover multiple edit operations involving interfa…

### DIFF
--- a/japicmp/src/main/java/japicmp/model/JApiClass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClass.java
@@ -786,6 +786,21 @@ public class JApiClass implements JApiHasModifiers, JApiHasChangeStatus, JApiHas
 				binaryCompatible = false;
 			}
 		}
+		if (binaryCompatible) {
+			for (JApiImplementedInterface anInterface : interfaces) {
+				// don't use JApiImplementedInterface.isBinaryCompatible(), since that checks the corresponding source
+				// without checking if this class still provides the equivalent methods from some other source
+				for (JApiCompatibilityChange change : anInterface.getCompatibilityChanges()) {
+					if (!change.isBinaryCompatible()) {
+						binaryCompatible = false;
+						break;
+					}
+				}
+				if (!binaryCompatible) {
+					break;
+				}
+			}
+		}
 		return binaryCompatible;
 	}
 
@@ -826,6 +841,21 @@ public class JApiClass implements JApiHasModifiers, JApiHasChangeStatus, JApiHas
 		if (sourceCompatible) {
 			if (!superclass.isSourceCompatible()) {
 				sourceCompatible = false;
+			}
+		}
+		if (sourceCompatible) {
+			for (JApiImplementedInterface anInterface : interfaces) {
+				// don't use JApiImplementedInterface.isSourceCompatible(), since that checks the corresponding source
+				// without checking if this class still provides the equivalent methods from some other source
+				for (JApiCompatibilityChange change : anInterface.getCompatibilityChanges()) {
+					if (!change.isSourceCompatible()) {
+						sourceCompatible = false;
+						break;
+					}
+				}
+				if (!sourceCompatible) {
+					break;
+				}
 			}
 		}
 		return sourceCompatible;

--- a/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
+++ b/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
@@ -16,7 +16,7 @@ public enum JApiCompatibilityChange {
 	SUPERCLASS_ADDED(true, true),
 	SUPERCLASS_MODIFIED_INCOMPATIBLE(false, false),
 	INTERFACE_ADDED(true, true),
-	INTERFACE_REMOVED(true, false),
+	INTERFACE_REMOVED(false, false),
 	METHOD_REMOVED(false, false),
 	METHOD_REMOVED_IN_SUPERCLASS(false, false),
 	METHOD_LESS_ACCESSIBLE(false, false),

--- a/japicmp/src/test/java/japicmp/cmp/InterfacesTest.java
+++ b/japicmp/src/test/java/japicmp/cmp/InterfacesTest.java
@@ -1,8 +1,11 @@
 package japicmp.cmp;
 
-import japicmp.config.Options;
-import japicmp.model.*;
-import japicmp.output.stdout.StdoutOutputGenerator;
+import japicmp.model.AccessModifier;
+import japicmp.model.JApiChangeStatus;
+import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiMethod;
+import japicmp.model.JApiSuperclass;
 import japicmp.util.CtClassBuilder;
 import japicmp.util.CtInterfaceBuilder;
 import japicmp.util.CtMethodBuilder;
@@ -187,6 +190,34 @@ public class InterfacesTest {
 	}
 
 	@Test
+	public void testClassNoLongerImplementsInterface() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtMethodBuilder.create().returnType(CtClass.voidType).publicAccess().abstractMethod().name("method").addToClass(ctClassInterface);
+				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassInterface).addToClassPool(classPool);
+				CtMethodBuilder.create().returnType(CtClass.voidType).publicAccess().name("method").addToClass(ctClass);
+				return Arrays.asList(ctClassInterface, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtMethodBuilder.create().returnType(CtClass.voidType).publicAccess().abstractMethod().name("method").addToClass(ctClassInterface);
+				CtClass ctClass = CtClassBuilder.create().name("Test").addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.REMOVED));
+	}
+
+	@Test
 	public void testInterfaceHierarchyHasOneMoreLevel() throws Exception {
 		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
 		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
@@ -203,7 +234,7 @@ public class InterfacesTest {
 				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
 				CtClass ctClassSubInterface = CtInterfaceBuilder.create().name("SubInterface").withSuperInterface(ctClassInterface).addToClassPool(classPool);
 				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassSubInterface).addToClassPool(classPool);
-				return Arrays.asList(ctClassInterface, ctClass);
+				return Arrays.asList(ctClassInterface, ctClassSubInterface, ctClass);
 			}
 		});
 		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
@@ -212,5 +243,98 @@ public class InterfacesTest {
 		assertThat(jApiClass.getInterfaces().size(), is(2));
 		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
 		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "SubInterface").getChangeStatus(), is(JApiChangeStatus.NEW));
+	}
+
+	@Test
+	public void testInterfaceHierarchyHasOneLessLevel() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClassSubInterface = CtInterfaceBuilder.create().name("SubInterface").withSuperInterface(ctClassInterface).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassSubInterface).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClassSubInterface, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassInterface).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		assertThat(jApiClass.getInterfaces().size(), is(2));
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "SubInterface").getChangeStatus(), is(JApiChangeStatus.REMOVED));
+	}
+
+	@Test
+	public void testInterfaceMovedToSuperclass() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClassSuperClass = CtClassBuilder.create().name("SuperClass").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassInterface).withSuperclass(ctClassSuperClass).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClassSuperClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClassSuperClass = CtClassBuilder.create().name("SuperClass").implementsInterface(ctClassInterface).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassSuperClass).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClassSuperClass, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+		assertThat(jApiClass.getInterfaces().size(), is(1));
+		JApiSuperclass jApiSuperclass = jApiClass.getSuperclass();
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		assertThat(jApiSuperclass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+	}
+
+	@Test
+	public void testInterfaceMovedToSubclass() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClassSuperClass = CtClassBuilder.create().name("SuperClass").implementsInterface(ctClassInterface).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassSuperClass).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClassSuperClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassInterface = CtInterfaceBuilder.create().name("Interface").addToClassPool(classPool);
+				CtClass ctClassSuperClass = CtClassBuilder.create().name("SuperClass").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").implementsInterface(ctClassInterface).withSuperclass(ctClassSuperClass).addToClassPool(classPool);
+				return Arrays.asList(ctClassInterface, ctClassSuperClass, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+		assertThat(jApiClass.getInterfaces().size(), is(1));
+		JApiSuperclass jApiSuperclass = jApiClass.getSuperclass();
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.NEW));
+		assertThat(jApiSuperclass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		jApiClass = getJApiClass(jApiClasses, "SuperClass");
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		assertThat(jApiClass.getInterfaces().size(), is(1));
+		assertThat(getJApiImplementedInterface(jApiClass.getInterfaces(), "Interface").getChangeStatus(), is(JApiChangeStatus.REMOVED));
 	}
 }

--- a/japicmp/src/test/java/japicmp/cmp/SuperclassTest.java
+++ b/japicmp/src/test/java/japicmp/cmp/SuperclassTest.java
@@ -1,8 +1,10 @@
 package japicmp.cmp;
 
+import japicmp.model.AccessModifier;
 import japicmp.model.JApiChangeStatus;
 import japicmp.model.JApiClass;
 import japicmp.util.CtClassBuilder;
+import japicmp.util.CtInterfaceBuilder;
 import javassist.ClassPool;
 import javassist.CtClass;
 import org.junit.Test;
@@ -12,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static japicmp.util.Helper.getJApiClass;
+import static japicmp.util.Helper.getJApiImplementedInterface;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -88,5 +91,90 @@ public class SuperclassTest {
 		assertThat(jApiClass.getSuperclass().getOldSuperclass().isPresent(), is(true));
 		assertThat(jApiClass.getSuperclass().getNewSuperclass().isPresent(), is(false));
 		assertThat(jApiClass.getSuperclass().getOldSuperclass().get().getName(), is("japicmp.Super"));
+	}
+
+	@Test
+	public void testClassHierarchyHasOneMoreLevel() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtInterfaceBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassBase).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtClassBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClassIntermediate = CtClassBuilder.create().name("Intermediate").withSuperclass(ctClassBase).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassIntermediate).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClassIntermediate, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+		assertThat(jApiClass.getSuperclass().getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		jApiClass = getJApiClass(jApiClasses, "Intermediate");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.NEW));
+	}
+
+	@Test
+	public void testClassHierarchyHasOneMoreLevelWithExistingClasses() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtInterfaceBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClassIntermediate = CtClassBuilder.create().name("Intermediate").withSuperclass(ctClassBase).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassBase).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClassIntermediate, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtClassBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClassIntermediate = CtClassBuilder.create().name("Intermediate").withSuperclass(ctClassBase).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassIntermediate).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClassIntermediate, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+		assertThat(jApiClass.getSuperclass().getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		jApiClass = getJApiClass(jApiClasses, "Intermediate");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+	}
+
+	@Test
+	public void testClassHierarchyHasOneLessLevel() throws Exception {
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = new JarArchiveComparatorOptions();
+		jarArchiveComparatorOptions.setAccessModifier(AccessModifier.PRIVATE);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtClassBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClassIntermediate = CtClassBuilder.create().name("Intermediate").withSuperclass(ctClassBase).addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassIntermediate).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClassIntermediate, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClassBase = CtInterfaceBuilder.create().name("Base").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("Test").withSuperclass(ctClassBase).addToClassPool(classPool);
+				return Arrays.asList(ctClassBase, ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "Test");
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		assertThat(jApiClass.getSuperclass().getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		jApiClass = getJApiClass(jApiClasses, "Intermediate");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.REMOVED));
 	}
 }


### PR DESCRIPTION
…ces and superclasses

 * removing interfaces from a class
 * removing an interface from the middle of a hierarchy
 * changing which class in a hierarchy implements an interface
 * inserting a superclass into a hierarchy, or removing one
 * removing interfaces now correctly qualify as binary incompatible, as type substitution will no longer work for those interfaces