### PR TITLE
Allow skipping via a property

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -69,7 +69,7 @@ public class JApiCmpMojo extends AbstractMojo {
 	private List<Dependency> oldClassPathDependencies;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private List<Dependency> newClassPathDependencies;
-	@org.apache.maven.plugins.annotations.Parameter(required = false)
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.skip", required = false)
 	private String skip;
 	@org.apache.maven.plugins.annotations.Parameter(property = "project.build.directory", required = true)
 	private File projectBuildDir;


### PR DESCRIPTION
This adds the ability to skip execution on the command line:
```
  $ mvn -Djapicmp.skip=true clean verify
```

This is a fairly standard convention followed by other plugins
such as the enforcer plugin, and core plugins like the jar and
source plugins.