### PR TITLE
Add CLI suport to error on incompatibilities

### DIFF
--- a/japicmp-ant-task/src/main/java/japicmp/ant/JApiCmpTask.java
+++ b/japicmp-ant-task/src/main/java/japicmp/ant/JApiCmpTask.java
@@ -3,7 +3,9 @@ package japicmp.ant;
 import japicmp.cmp.JarArchiveComparator;
 import japicmp.cmp.JarArchiveComparatorOptions;
 import japicmp.config.Options;
+import japicmp.exception.JApiCmpException;
 import japicmp.model.JApiClass;
+import japicmp.output.incompatible.IncompatibleErrorOutput;
 import japicmp.output.semver.SemverOut;
 import japicmp.output.stdout.StdoutOutputGenerator;
 import japicmp.output.xml.XmlOutput;
@@ -45,6 +47,13 @@ public class JApiCmpTask extends Task {
 	private String xmlOutputFile;
 	private String htmlOutputFile;
 	private String htmlStylesheet;
+	private boolean errorOnSemanticIncompatibility = false;
+	private boolean errorOnExclusionIncompatibility = false;
+	private boolean errorOnSourceIncompatibility = false;
+	private boolean errorOnBinaryIncompatibility = false;
+	private boolean errorOnModifications = false;
+	private boolean ignoreMissingOldVersion = false;
+	private boolean ignoreMissingNewVersion = false;
 
 	public void setOnlyBinaryIncompatible(String onlyBinaryIncompatible) {
 		this.onlyBinaryIncompatible = Project.toBoolean(onlyBinaryIncompatible);
@@ -163,6 +172,34 @@ public class JApiCmpTask extends Task {
 		this.htmlStylesheet = htmlStylesheet;
 	}
 
+	public boolean isErrorOnSemanticIncompatibility() {
+		return errorOnSemanticIncompatibility;
+	}
+
+	public boolean isErrorOnExclusionIncompatibility() {
+		return errorOnExclusionIncompatibility;
+	}
+
+	public boolean isErrorOnSourceIncompatibility() {
+		return errorOnSourceIncompatibility;
+	}
+
+	public boolean isErrorOnBinaryIncompatibility() {
+		return errorOnBinaryIncompatibility;
+	}
+
+	public boolean isErrorOnModifications() {
+		return errorOnModifications;
+	}
+
+	public boolean isIgnoreMissingOldVersion() {
+		return ignoreMissingOldVersion;
+	}
+
+	public boolean isIgnoreMissingNewVersion() {
+		return ignoreMissingNewVersion;
+	}
+
 	@Override
 	public void execute() {
 		if (oldJar == null) {
@@ -174,7 +211,7 @@ public class JApiCmpTask extends Task {
 		Options options = createOptionsFromAntAttrs();
 		JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(JarArchiveComparatorOptions.of(options));
 		List<JApiClass> jApiClasses = jarArchiveComparator.compare(options.getOldArchives(), options.getNewArchives());
-		generateOutput(options, jApiClasses);
+		generateOutput(options, jApiClasses, jarArchiveComparator);
 	}
 
 	private Options createOptionsFromAntAttrs() {
@@ -198,11 +235,18 @@ public class JApiCmpTask extends Task {
 			options.addIgnoreMissingClassRegularExpression(missingClassRegEx);
 		}
 		options.setReportOnlyFilename(reportOnlyFilename);
+		options.setErrorOnSemanticIncompatibility(errorOnSemanticIncompatibility);
+		options.setErrorOnExclusionIncompatibility(errorOnExclusionIncompatibility);
+		options.setErrorOnSourceIncompatibility(errorOnSourceIncompatibility);
+		options.setErrorOnBinaryIncompatibility(errorOnBinaryIncompatibility);
+		options.setErrorOnModifications(errorOnModifications);
+		options.setIgnoreMissingOldVersion(ignoreMissingOldVersion);
+		options.setIgnoreMissingNewVersion(ignoreMissingNewVersion);
 		options.verify();
 		return options;
 	}
 
-	private void generateOutput(Options options, List<JApiClass> jApiClasses) {
+	private void generateOutput(Options options, List<JApiClass> jApiClasses, JarArchiveComparator jarArchiveComparator) {
 		if (semanticVersioning) {
 			SemverOut semverOut = new SemverOut(options, jApiClasses);
 			String semver = semverOut.generate();
@@ -229,5 +273,21 @@ public class JApiCmpTask extends Task {
         } catch (Exception e) {
             throw new BuildException("Could not close output streams: " + e.getMessage(), e);
         }
+
+		if (options.isErrorOnBinaryIncompatibility()
+			|| options.isErrorOnSourceIncompatibility()
+			|| options.isErrorOnExclusionIncompatibility()
+			|| options.isErrorOnModifications()
+			|| options.isErrorOnSemanticIncompatibility()) {
+			IncompatibleErrorOutput errorOutput = new IncompatibleErrorOutput(options, jApiClasses, jarArchiveComparator);
+			try {
+				errorOutput.generate();
+			} catch (JApiCmpException e) {
+				if (e.getReason() == JApiCmpException.Reason.IncompatibleChange) {
+					throw new BuildException(e.getMessage());
+				}
+				throw e;
+			}
+		}
 	}
 }

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -371,8 +371,8 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (breakBuildOnModificationsParameter(parameterParam)) {
 			options.setErrorOnModifications(true);
 		}
-		if (parameterParam.isBreakBuildIfCausedByExclusion()) {
-			options.setErrorOnExclusionIncompatibility(true);
+		if (!parameterParam.isBreakBuildIfCausedByExclusion()) {
+			options.setErrorOnExclusionIncompatibility(false);
 		}
 		if (parameter != null && "true".equalsIgnoreCase(parameter.getIgnoreMissingOldVersion() == null ? "false" : parameter.getIgnoreMissingOldVersion())) {
 			options.setIgnoreMissingOldVersion(true);

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
@@ -19,6 +19,7 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Test;
@@ -46,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class JApiCmpMojoTest {
 
 	@Test
-	public void testSimple() throws MojoFailureException {
+	public void testSimple() throws MojoFailureException, MojoExecutionException {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");
@@ -69,7 +70,7 @@ public class JApiCmpMojoTest {
 	}
 
 	@Test
-	public void testNoXmlAndNoHtmlNoDiffReport() throws MojoFailureException {
+	public void testNoXmlAndNoHtmlNoDiffReport() throws MojoFailureException, MojoExecutionException {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");
@@ -140,7 +141,7 @@ public class JApiCmpMojoTest {
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
 		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
 		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
-		mojo.breakBuildIfNecessaryByApplyingFilter(compareClassesResult.getjApiClasses(), parameterParam, options, new JarArchiveComparator(jarArchiveComparatorOptions));
+		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, new JarArchiveComparator(jarArchiveComparatorOptions));
 	}
 
 	@Test
@@ -179,7 +180,7 @@ public class JApiCmpMojoTest {
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
 		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
 		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
-		mojo.breakBuildIfNecessaryByApplyingFilter(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
+		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
 	@Test
@@ -218,7 +219,7 @@ public class JApiCmpMojoTest {
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
 		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
 		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
-		mojo.breakBuildIfNecessaryByApplyingFilter(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
+		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
 	@Test
@@ -255,7 +256,7 @@ public class JApiCmpMojoTest {
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
 		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
 		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
-		mojo.breakBuildIfNecessaryByApplyingFilter(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
+		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
 	@Test
@@ -283,7 +284,7 @@ public class JApiCmpMojoTest {
 		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
 		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
 		try {
-			mojo.breakBuildIfNecessaryByApplyingFilter(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
+			mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 			fail("No exception thrown.");
 		} catch (MojoFailureException e) {
 			String msg = e.getMessage();
@@ -295,7 +296,7 @@ public class JApiCmpMojoTest {
 	}
 
 	@Test
-	public void testIgnoreMissingVersions() throws MojoFailureException, IOException {
+	public void testIgnoreMissingVersions() throws MojoFailureException, IOException, MojoExecutionException {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");

--- a/japicmp/src/main/java/japicmp/cli/CliParser.java
+++ b/japicmp/src/main/java/japicmp/cli/CliParser.java
@@ -91,7 +91,7 @@ public class CliParser {
 				options.setErrorOnBinaryIncompatibility(true);
 			} else if ("--error-on-source-incompatibility".equals(arg)) {
 				options.setErrorOnSourceIncompatibility(true);
-			} else if ("--error-on-binary-incompatibility".equals(arg)) {
+			} else if ("--error-on-exclusion-incompatibility".equals(arg)) {
 				options.setErrorOnExclusionIncompatibility(true);
 			} else if ("--error-on-modifications".equals(arg)) {
 				options.setErrorOnModifications(true);

--- a/japicmp/src/main/java/japicmp/cli/CliParser.java
+++ b/japicmp/src/main/java/japicmp/cli/CliParser.java
@@ -91,8 +91,8 @@ public class CliParser {
 				options.setErrorOnBinaryIncompatibility(true);
 			} else if ("--error-on-source-incompatibility".equals(arg)) {
 				options.setErrorOnSourceIncompatibility(true);
-			} else if ("--error-on-exclusion-incompatibility".equals(arg)) {
-				options.setErrorOnExclusionIncompatibility(true);
+			} else if ("--no-error-on-exclusion-incompatibility".equals(arg)) {
+				options.setErrorOnExclusionIncompatibility(false);
 			} else if ("--error-on-modifications".equals(arg)) {
 				options.setErrorOnModifications(true);
 			} else if ("--error-on-semantic-incompatibility".equals(arg)) {
@@ -124,6 +124,12 @@ public class CliParser {
 			"                [--old-classpath <oldClassPath>] [--report-only-filename]\n" +
 			"                [(-s | --semantic-versioning)]\n" +
 			"                [(-x <pathToXmlOutputFile> | --xml-file <pathToXmlOutputFile>)]\n" +
+			"                [--error-on-binary-incompatibility]\n" +
+			"                [--error-on-source-incompatibility]\n" +
+			"                [--error-on-modifications]\n" +
+			"                [--no-error-on-exclusion-incompatibility]\n" +
+			"                [--error-on-semantic-incompatibility]\n" +
+			"                [--ignore-missing-old-version] [--ignore-missing-new-version]\n" +
 			"\n" +
 			"OPTIONS\n" +
 			"        -a <accessModifier>\n" +
@@ -201,7 +207,36 @@ public class CliParser {
 			"            Tells you which part of the version to increment.\n" +
 			"\n" +
 			"        -x <pathToXmlOutputFile>, --xml-file <pathToXmlOutputFile>\n" +
-			"            Provides the path to the xml output file.");
+			"            Provides the path to the xml output file.\n" +
+			"\n" +
+			"        --error-on-binary-incompatibility\n" +
+			"            Exit with an error if a binary incompatibility is detected.\n" +
+			"\n" +
+			"        --error-on-source-incompatibility\n" +
+			"            Exit with an error if a source incompatibility is detected.\n" +
+			"\n" +
+			"        --error-on-modifications\n" +
+			"            Exit with an error if any change between versions is detected.\n" +
+			"\n" +
+			"        --no-error-on-exclusion-incompatibility\n" +
+			"            Ignore incompatible changes caused by an excluded class\n" +
+			"            (e.g. excluded interface removed from not excluded class) when\n" +
+			"            deciding whether to exit with an error.\n" +
+			"\n" +
+			"        --error-on-semantic-incompatibility\n" +
+			"            Exit with an error if the binary compatibility changes are\n" +
+			"            inconsistent with Semantic Versioning. This expects versions of\n" +
+			"            the form Major.Minor.Patch (e.g. 1.2.3 or 1.2.3-SNAPSHOT).\n" +
+			"            See http://semver.org/spec/v2.0.0.html for more information about\n" +
+			"            Semantic Versioning.\n" +
+			"\n" +
+			"        --ignore-missing-old-version\n" +
+			"            When --error-on-semantic-incompatibility is passed, ignore\n" +
+			"            non-resolvable artifacts for the old version.\n" +
+			"\n" +
+			"        --ignore-missing-new-version\n" +
+			"            When --error-on-semantic-incompatibility is passed, ignore\n" +
+			"            non-resolvable artifacts for the new version.\n");
 	}
 
 	private String getOptionWithArgument(String option, StringArrayEnumeration sae) {

--- a/japicmp/src/main/java/japicmp/cli/CliParser.java
+++ b/japicmp/src/main/java/japicmp/cli/CliParser.java
@@ -87,6 +87,20 @@ public class CliParser {
 				options.setNoAnnotations(true);
 			} else if ("--report-only-filename".equals(arg)) {
 				options.setReportOnlyFilename(true);
+			} else if ("--error-on-binary-incompatibility".equals(arg)) {
+				options.setErrorOnBinaryIncompatibility(true);
+			} else if ("--error-on-source-incompatibility".equals(arg)) {
+				options.setErrorOnSourceIncompatibility(true);
+			} else if ("--error-on-binary-incompatibility".equals(arg)) {
+				options.setErrorOnExclusionIncompatibility(true);
+			} else if ("--error-on-modifications".equals(arg)) {
+				options.setErrorOnModifications(true);
+			} else if ("--error-on-semantic-incompatibility".equals(arg)) {
+				options.setErrorOnSemanticIncompatibility(true);
+			} else if ("--ignore-missing-old-version".equals(arg)) {
+				options.setIgnoreMissingOldVersion(true);
+			} else if ("--ignore-missing-new-version".equals(arg)) {
+				options.setIgnoreMissingNewVersion(true);
 			} else {
 				throw new JApiCmpException(JApiCmpException.Reason.CliError, "Unknown argument: " + arg);
 			}

--- a/japicmp/src/main/java/japicmp/cli/JApiCli.java
+++ b/japicmp/src/main/java/japicmp/cli/JApiCli.java
@@ -5,6 +5,7 @@ import japicmp.cmp.JarArchiveComparatorOptions;
 import japicmp.config.Options;
 import japicmp.exception.JApiCmpException;
 import japicmp.model.JApiClass;
+import japicmp.output.incompatible.IncompatibleErrorOutput;
 import japicmp.output.semver.SemverOut;
 import japicmp.output.stdout.StdoutOutputGenerator;
 import japicmp.output.xml.XmlOutput;
@@ -28,10 +29,10 @@ public class JApiCli {
 		}
 		JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(JarArchiveComparatorOptions.of(options));
 		List<JApiClass> jApiClasses = jarArchiveComparator.compare(options.getOldArchives(), options.getNewArchives());
-		generateOutput(options, jApiClasses);
+		generateOutput(options, jApiClasses, jarArchiveComparator);
 	}
 
-	private void generateOutput(Options options, List<JApiClass> jApiClasses) {
+	private void generateOutput(Options options, List<JApiClass> jApiClasses, JarArchiveComparator jarArchiveComparator) {
 		if (options.isSemanticVersioning()) {
 			SemverOut semverOut = new SemverOut(options, jApiClasses);
 			String output = semverOut.generate();
@@ -53,5 +54,12 @@ public class JApiCli {
 		StdoutOutputGenerator stdoutOutputGenerator = new StdoutOutputGenerator(options, jApiClasses);
 		String output = stdoutOutputGenerator.generate();
 		System.out.println(output);
+
+		if (options.isErrorOnBinaryIncompatibility()
+			|| options.isErrorOnSourceIncompatibility()
+			|| options.isErrorOnExclusionIncompatibility()) {
+			IncompatibleErrorOutput errorOutput = new IncompatibleErrorOutput(options, jApiClasses, jarArchiveComparator);
+			errorOutput.generate();
+		}
 	}
 }

--- a/japicmp/src/main/java/japicmp/cli/JApiCli.java
+++ b/japicmp/src/main/java/japicmp/cli/JApiCli.java
@@ -57,7 +57,9 @@ public class JApiCli {
 
 		if (options.isErrorOnBinaryIncompatibility()
 			|| options.isErrorOnSourceIncompatibility()
-			|| options.isErrorOnExclusionIncompatibility()) {
+			|| options.isErrorOnExclusionIncompatibility()
+			|| options.isErrorOnModifications()
+			|| options.isErrorOnSemanticIncompatibility()) {
 			IncompatibleErrorOutput errorOutput = new IncompatibleErrorOutput(options, jApiClasses, jarArchiveComparator);
 			errorOutput.generate();
 		}

--- a/japicmp/src/main/java/japicmp/config/Options.java
+++ b/japicmp/src/main/java/japicmp/config/Options.java
@@ -50,7 +50,7 @@ public class Options {
 	private boolean semanticVersioning;
 	private boolean errorOnBinaryIncompatibility;
 	private boolean errorOnSourceIncompatibility;
-	private boolean errorOnExclusionIncompatibility;
+	private boolean errorOnExclusionIncompatibility = true;
 	private boolean errorOnModifications;
 	private boolean errorOnSemanticIncompatibility;
 	private boolean ignoreMissingOldVersion;

--- a/japicmp/src/main/java/japicmp/config/Options.java
+++ b/japicmp/src/main/java/japicmp/config/Options.java
@@ -48,6 +48,13 @@ public class Options {
 	private boolean noAnnotations = false;
 	private boolean reportOnlyFilename;
 	private boolean semanticVersioning;
+	private boolean errorOnBinaryIncompatibility;
+	private boolean errorOnSourceIncompatibility;
+	private boolean errorOnExclusionIncompatibility;
+	private boolean errorOnModifications;
+	private boolean errorOnSemanticIncompatibility;
+	private boolean ignoreMissingOldVersion;
+	private boolean ignoreMissingNewVersion;
 	private boolean helpRequested;
 
 	Options() {
@@ -382,6 +389,62 @@ public class Options {
 
 	public boolean isSemanticVersioning() {
 		return semanticVersioning;
+	}
+
+	public boolean isErrorOnBinaryIncompatibility() {
+		return errorOnBinaryIncompatibility;
+	}
+
+	public void setErrorOnBinaryIncompatibility(boolean errorOnBinaryIncompatibility) {
+		this.errorOnBinaryIncompatibility = errorOnBinaryIncompatibility;
+	}
+
+	public boolean isErrorOnSourceIncompatibility() {
+		return errorOnSourceIncompatibility;
+	}
+
+	public void setErrorOnSourceIncompatibility(boolean errorOnSourceIncompatibility) {
+		this.errorOnSourceIncompatibility = errorOnSourceIncompatibility;
+	}
+
+	public boolean isErrorOnExclusionIncompatibility() {
+		return errorOnExclusionIncompatibility;
+	}
+
+	public void setErrorOnExclusionIncompatibility(boolean errorOnExclusionIncompatibility) {
+		this.errorOnExclusionIncompatibility = errorOnExclusionIncompatibility;
+	}
+
+	public boolean isErrorOnModifications() {
+		return errorOnModifications;
+	}
+
+	public void setErrorOnModifications(boolean errorOnModifications) {
+		this.errorOnModifications = errorOnModifications;
+	}
+
+	public boolean isErrorOnSemanticIncompatibility() {
+		return errorOnSemanticIncompatibility;
+	}
+
+	public void setErrorOnSemanticIncompatibility(boolean errorOnSemanticIncompatibility) {
+		this.errorOnSemanticIncompatibility = errorOnSemanticIncompatibility;
+	}
+
+	public boolean isIgnoreMissingOldVersion() {
+		return ignoreMissingOldVersion;
+	}
+
+	public void setIgnoreMissingOldVersion(boolean ignoreMissingOldVersion) {
+		this.ignoreMissingOldVersion = ignoreMissingOldVersion;
+	}
+
+	public boolean isIgnoreMissingNewVersion() {
+		return ignoreMissingNewVersion;
+	}
+
+	public void setIgnoreMissingNewVersion(boolean ignoreMissingNewVersion) {
+		this.ignoreMissingNewVersion = ignoreMissingNewVersion;
 	}
 
 	public boolean isHelpRequested() {

--- a/japicmp/src/main/java/japicmp/exception/JApiCmpException.java
+++ b/japicmp/src/main/java/japicmp/exception/JApiCmpException.java
@@ -14,7 +14,9 @@ public class JApiCmpException extends RuntimeException {
 		JaxbException,
 		ClassLoading,
 		IllegalState,
-		IllegalArgument, XsltError
+		IllegalArgument,
+		XsltError,
+		IncompatibleChange
 	}
 
 	public JApiCmpException(Reason reason, String msg) {

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -83,7 +83,7 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 		if (options.isErrorOnModifications()) {
 			for (JApiClass jApiClass : jApiClasses) {
 				if (jApiClass.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
-					throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("Breaking the build because there is at least one modified class: %s", jApiClass.getFullyQualifiedName()));
+					throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("There is at least one modified class: %s", jApiClass.getFullyQualifiedName()));
 				}
 			}
 		}
@@ -400,7 +400,7 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 			}
 		});
 		if (breakBuildResult.breakTheBuild()) {
-			throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("Breaking the build because there is at least one incompatibility: %s", sb.toString()));
+			throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("There is at least one incompatibility: %s", sb.toString()));
 		}
 	}
 }

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package japicmp.output.incompatible;
+
+import com.google.common.base.Joiner;
+import japicmp.JApiCmp;
+import japicmp.cmp.JApiCmpArchive;
+import japicmp.cmp.JarArchiveComparator;
+import japicmp.config.Options;
+import japicmp.exception.JApiCmpException;
+import japicmp.filter.ClassFilter;
+import japicmp.model.JApiAnnotation;
+import japicmp.model.JApiBehavior;
+import japicmp.model.JApiChangeStatus;
+import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiConstructor;
+import japicmp.model.JApiField;
+import japicmp.model.JApiImplementedInterface;
+import japicmp.model.JApiMethod;
+import japicmp.model.JApiParameter;
+import japicmp.model.JApiReturnType;
+import japicmp.model.JApiSuperclass;
+import japicmp.model.JApiType;
+import japicmp.output.Filter;
+import japicmp.output.OutputGenerator;
+import japicmp.output.semver.SemverOut;
+import japicmp.util.Optional;
+import japicmp.versioning.SemanticVersion;
+import japicmp.versioning.VersionChange;
+import javassist.CtClass;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class IncompatibleErrorOutput extends OutputGenerator<Void> {
+
+	private static final Logger LOGGER = Logger.getLogger(JApiCmp.class.getName());
+
+	private final JarArchiveComparator jarArchiveComparator;
+
+	public IncompatibleErrorOutput(Options options, List<JApiClass> jApiClasses, JarArchiveComparator jarArchiveComparator) {
+		super(options, jApiClasses);
+		this.jarArchiveComparator = jarArchiveComparator;
+	}
+
+	protected void warn(String msg, Throwable exception) {
+		LOGGER.log(Level.WARNING, msg, exception);
+	}
+
+	protected void info(String msg) {
+		LOGGER.log(Level.INFO, "Skipping semantic version check because all major versions are zero (see http://semver.org/#semantic-versioning-specification-semver, section 4).");
+	}
+
+	protected void debug(String msg) {
+		LOGGER.log(Level.FINE, "Skipping semantic version check because all major versions are zero (see http://semver.org/#semantic-versioning-specification-semver, section 4).");
+	}
+
+	protected boolean isDebugEnabled() {
+		return LOGGER.isLoggable(Level.FINE);
+	}
+
+	@Override
+	public Void generate() {
+		if (options.isErrorOnModifications()) {
+			for (JApiClass jApiClass : jApiClasses) {
+				if (jApiClass.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
+					throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("Breaking the build because there is at least one modified class: %s", jApiClass.getFullyQualifiedName()));
+				}
+			}
+		}
+		breakBuildIfNecessaryByApplyingFilter(jApiClasses, options, jarArchiveComparator);
+		if (options.isErrorOnSemanticIncompatibility()) {
+			boolean ignoreMissingOldVersion = options.isIgnoreMissingOldVersion();
+			boolean ignoreMissingNewVersion = options.isIgnoreMissingNewVersion();
+			List<SemanticVersion> oldVersions = new ArrayList<>();
+			List<SemanticVersion> newVersions = new ArrayList<>();
+			for (JApiCmpArchive file : options.getOldArchives()) {
+				Optional<SemanticVersion> semanticVersion = file.getVersion().getSemanticVersion();
+				if (semanticVersion.isPresent()) {
+					oldVersions.add(semanticVersion.get());
+				}
+			}
+			for (JApiCmpArchive file : options.getNewArchives()) {
+				Optional<SemanticVersion> semanticVersion = file.getVersion().getSemanticVersion();
+				if (semanticVersion.isPresent()) {
+					newVersions.add(semanticVersion.get());
+				}
+			}
+			VersionChange versionChange = new VersionChange(oldVersions, newVersions, ignoreMissingOldVersion, ignoreMissingNewVersion);
+			if (!versionChange.isAllMajorVersionsZero()) {
+				Optional<SemanticVersion.ChangeType> changeTypeOptional = versionChange.computeChangeType();
+				if (changeTypeOptional.isPresent()) {
+					SemanticVersion.ChangeType changeType = changeTypeOptional.get();
+					SemverOut semverOut = new SemverOut(options, jApiClasses);
+					String semver = semverOut.generate();
+					if (changeType == SemanticVersion.ChangeType.MINOR && semver.equals("1.0.0")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a minor change but binary incompatible changes found.");
+					}
+					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals("1.0.0")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a patch change but binary incompatible changes found.");
+					}
+					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals("0.1.0")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a patch change but binary compatible changes found.");
+					}
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("1.0.0")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but binary incompatible changes found.");
+					}
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("0.1.0")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but binary compatible changes found.");
+					}
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("0.0.1")) {
+						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but found API changes.");
+					}
+				} else {
+					if (isDebugEnabled()) {
+						Joiner joiner = Joiner.on(';');
+						debug("No change type available for old version(s) " + joiner.join(oldVersions) + " and new version(s) " + joiner.join(newVersions) + ".");
+					}
+				}
+			} else {
+				info("Skipping semantic version check because all major versions are zero (see http://semver.org/#semantic-versioning-specification-semver, section 4).");
+			}
+		}
+		return null;
+	}
+
+
+	private static class BreakBuildResult {
+		private final boolean breakBuildOnBinaryIncompatibleModifications;
+		private final boolean breakBuildOnSourceIncompatibleModifications;
+		boolean binaryIncompatibleChanges = false;
+		boolean sourceIncompatibleChanges = false;
+
+		public BreakBuildResult(boolean breakBuildOnBinaryIncompatibleModifications, boolean breakBuildOnSourceIncompatibleModifications) {
+			this.breakBuildOnBinaryIncompatibleModifications = breakBuildOnBinaryIncompatibleModifications;
+			this.breakBuildOnSourceIncompatibleModifications = breakBuildOnSourceIncompatibleModifications;
+		}
+
+		public boolean breakTheBuild() {
+			return binaryIncompatibleChanges && this.breakBuildOnBinaryIncompatibleModifications ||
+				sourceIncompatibleChanges && this.breakBuildOnSourceIncompatibleModifications;
+		}
+	}
+
+	private String methodParameterToList(JApiBehavior jApiMethod) {
+		StringBuilder sb = new StringBuilder();
+		for (JApiParameter jApiParameter : jApiMethod.getParameters()) {
+			if (sb.length() > 0) {
+				sb.append(',');
+			}
+			sb.append(jApiParameter.getType());
+		}
+		return sb.toString();
+	}
+
+	void breakBuildIfNecessaryByApplyingFilter(List<JApiClass> jApiClasses, final Options options,
+											   final JarArchiveComparator jarArchiveComparator) {
+		final StringBuilder sb = new StringBuilder();
+		final BreakBuildResult breakBuildResult = new BreakBuildResult(options.isErrorOnBinaryIncompatibility(),
+			options.isErrorOnSourceIncompatibility());
+		final boolean breakBuildIfCausedByExclusion = options.isErrorOnExclusionIncompatibility();
+		Filter.filter(jApiClasses, new Filter.FilterVisitor() {
+			@Override
+			public void visit(Iterator<JApiClass> iterator, JApiClass jApiClass) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiClass.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible()) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible()) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiClass.getFullyQualifiedName()).append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			@Override
+			public void visit(Iterator<JApiMethod> iterator, JApiMethod jApiMethod) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiMethod.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible() && breakBuildIfCausedByExclusion(jApiMethod)) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible() && breakBuildIfCausedByExclusion(jApiMethod)) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiMethod.getjApiClass().getFullyQualifiedName()).append(".").append(jApiMethod.getName()).append("(").append(methodParameterToList(jApiMethod)).append(")").append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			private boolean breakBuildIfCausedByExclusion(JApiMethod jApiMethod) {
+				if (!breakBuildIfCausedByExclusion) {
+					JApiReturnType returnType = jApiMethod.getReturnType();
+					String oldType = returnType.getOldReturnType();
+					try {
+						Optional<CtClass> ctClassOptional = jarArchiveComparator.loadClass(JarArchiveComparator.ArchiveType.OLD, oldType);
+						if (ctClassOptional.isPresent()) {
+							if (classExcluded(ctClassOptional.get())) {
+								return false;
+							}
+						}
+					} catch (Exception e) {
+						warn("Failed to load class " + oldType + ": " + e.getMessage(), e);
+					}
+					String newType = returnType.getNewReturnType();
+					try {
+						Optional<CtClass> ctClassOptional = jarArchiveComparator.loadClass(JarArchiveComparator.ArchiveType.NEW, newType);
+						if (ctClassOptional.isPresent()) {
+							if (classExcluded(ctClassOptional.get())) {
+								return false;
+							}
+						}
+					} catch (Exception e) {
+						warn("Failed to load class " + newType + ": " + e.getMessage(), e);
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public void visit(Iterator<JApiConstructor> iterator, JApiConstructor jApiConstructor) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiConstructor.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible()) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible()) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiConstructor.getjApiClass().getFullyQualifiedName()).append(".").append(jApiConstructor.getName()).append("(").append(methodParameterToList(jApiConstructor)).append(")").append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			@Override
+			public void visit(Iterator<JApiImplementedInterface> iterator, JApiImplementedInterface jApiImplementedInterface) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiImplementedInterface.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible() && breakBuildIfCausedByExclusion(jApiImplementedInterface)) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible() && breakBuildIfCausedByExclusion(jApiImplementedInterface)) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiImplementedInterface.getFullyQualifiedName()).append("[").append(jApiImplementedInterface.getFullyQualifiedName()).append("]").append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			private boolean breakBuildIfCausedByExclusion(JApiImplementedInterface jApiImplementedInterface) {
+				if (!breakBuildIfCausedByExclusion) {
+					CtClass ctClass = jApiImplementedInterface.getCtClass();
+					if (classExcluded(ctClass)) {
+						return false;
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public void visit(Iterator<JApiField> iterator, JApiField jApiField) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiField.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible() && breakBuildIfCausedByExclusion(jApiField)) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible() && breakBuildIfCausedByExclusion(jApiField)) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiField.getjApiClass().getFullyQualifiedName()).append(".").append(jApiField.getName()).append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			private boolean breakBuildIfCausedByExclusion(JApiField jApiField) {
+				if (!breakBuildIfCausedByExclusion) {
+					JApiType type = jApiField.getType();
+					Optional<String> oldTypeOptional = type.getOldTypeOptional();
+					if (oldTypeOptional.isPresent()) {
+						String oldType = oldTypeOptional.get();
+						try {
+							Optional<CtClass> ctClassOptional = jarArchiveComparator.loadClass(JarArchiveComparator.ArchiveType.OLD, oldType);
+							if (ctClassOptional.isPresent()) {
+								if (classExcluded(ctClassOptional.get())) {
+									return false;
+								}
+							}
+						} catch (Exception e) {
+							warn("Failed to load class " + oldType + ": " + e.getMessage(), e);
+						}
+					}
+					Optional<String> newTypeOptional = type.getNewTypeOptional();
+					if (newTypeOptional.isPresent()) {
+						String newType = newTypeOptional.get();
+						try {
+							Optional<CtClass> ctClassOptional = jarArchiveComparator.loadClass(JarArchiveComparator.ArchiveType.NEW, newType);
+							if (ctClassOptional.isPresent()) {
+								if (classExcluded(ctClassOptional.get())) {
+									return false;
+								}
+							}
+						} catch (Exception e) {
+							warn("Failed to load class " + newType + ": " + e.getMessage(), e);
+						}
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public void visit(Iterator<JApiAnnotation> iterator, JApiAnnotation jApiAnnotation) {
+				//no incompatible changes
+			}
+
+			@Override
+			public void visit(JApiSuperclass jApiSuperclass) {
+				for (JApiCompatibilityChange jApiCompatibilityChange : jApiSuperclass.getCompatibilityChanges()) {
+					if (!jApiCompatibilityChange.isBinaryCompatible() || !jApiCompatibilityChange.isSourceCompatible()) {
+						if (!jApiCompatibilityChange.isBinaryCompatible() && breakBuildIfCausedByExclusion(jApiSuperclass)) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!jApiCompatibilityChange.isSourceCompatible() && breakBuildIfCausedByExclusion(jApiSuperclass)) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiSuperclass.getJApiClassOwning().getFullyQualifiedName()).append(":").append(jApiCompatibilityChange.name());
+					}
+				}
+			}
+
+			private boolean breakBuildIfCausedByExclusion(JApiSuperclass jApiSuperclass) {
+				if (!breakBuildIfCausedByExclusion) {
+					Optional<CtClass> oldSuperclassOptional = jApiSuperclass.getOldSuperclass();
+					if (oldSuperclassOptional.isPresent()) {
+						CtClass ctClass = oldSuperclassOptional.get();
+						if (classExcluded(ctClass)) {
+							return false;
+						}
+					}
+					Optional<CtClass> newSuperclassOptional = jApiSuperclass.getNewSuperclass();
+					if (newSuperclassOptional.isPresent()) {
+						CtClass ctClass = newSuperclassOptional.get();
+						if (classExcluded(ctClass)) {
+							return false;
+						}
+					}
+				}
+				return true;
+			}
+
+			private boolean classExcluded(CtClass ctClass) {
+				List<japicmp.filter.Filter> excludes = options.getExcludes();
+				for (japicmp.filter.Filter exclude : excludes) {
+					if (exclude instanceof ClassFilter) {
+						ClassFilter classFilter = (ClassFilter) exclude;
+						if (classFilter.matches(ctClass)) {
+							return true;
+						}
+					}
+				}
+				return false;
+			}
+		});
+		if (breakBuildResult.breakTheBuild()) {
+			throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, String.format("Breaking the build because there is at least one incompatibility: %s", sb.toString()));
+		}
+	}
+}

--- a/japicmp/src/test/java/japicmp/cmp/ClassesHelper.java
+++ b/japicmp/src/test/java/japicmp/cmp/ClassesHelper.java
@@ -21,4 +21,30 @@ public class ClassesHelper {
 		List<CtClass> newClasses = classesGenerator.createNewClasses(classPool);
 		return jarArchiveComparator.compareClassLists(options, oldClasses, newClasses);
 	}
+
+	public static class CompareClassesResult {
+		final List<JApiClass> jApiClasses;
+		final JarArchiveComparator jarArchiveComparator;
+
+		public CompareClassesResult(List<JApiClass> jApiClasses, JarArchiveComparator jarArchiveComparator) {
+			this.jApiClasses = jApiClasses;
+			this.jarArchiveComparator = jarArchiveComparator;
+		}
+
+		public List<JApiClass> getjApiClasses() {
+			return jApiClasses;
+		}
+
+		public JarArchiveComparator getJarArchiveComparator() {
+			return jarArchiveComparator;
+		}
+	}
+
+	public static CompareClassesResult compareClassesWithResult(JarArchiveComparatorOptions options, ClassesGenerator classesGenerator) throws Exception {
+		JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(options);
+		ClassPool classPool = jarArchiveComparator.getCommonClassPool();
+		List<CtClass> oldClasses = classesGenerator.createOldClasses(classPool);
+		List<CtClass> newClasses = classesGenerator.createNewClasses(classPool);
+		return new CompareClassesResult(jarArchiveComparator.compareClassLists(options, oldClasses, newClasses), jarArchiveComparator);
+	}
 }

--- a/japicmp/src/test/java/japicmp/output/incompatible/IncompatibleErrorOutputTest.java
+++ b/japicmp/src/test/java/japicmp/output/incompatible/IncompatibleErrorOutputTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package japicmp.output.incompatible;
+
+import japicmp.cmp.ClassesHelper;
+import japicmp.cmp.JarArchiveComparatorOptions;
+import japicmp.config.Options;
+import japicmp.exception.JApiCmpException;
+import japicmp.util.CtClassBuilder;
+import japicmp.util.CtFieldBuilder;
+import japicmp.util.CtInterfaceBuilder;
+import japicmp.util.CtMethodBuilder;
+import japicmp.util.Optional;
+import javassist.ClassPool;
+import javassist.CtClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IncompatibleErrorOutputTest {
+
+	@Test
+	public void testBreakBuildIfNecessaryFieldTypeChangedCausedByExclusionFalse() throws Exception {
+		testBreakBuildIfNecessaryFieldTypeChangedCausedByExclusion(false);
+	}
+
+	@Test(expected = JApiCmpException.class)
+	public void testBreakBuildIfNecessaryFieldTypeChangedCausedByExclusionTrue() throws Exception {
+		testBreakBuildIfNecessaryFieldTypeChangedCausedByExclusion(true);
+	}
+
+	private void testBreakBuildIfNecessaryFieldTypeChangedCausedByExclusion(boolean breakBuildIfCausedByExclusion) throws Exception {
+		Options options = Options.newDefault();
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = JarArchiveComparatorOptions.of(options);
+		ClassesHelper.CompareClassesResult result = ClassesHelper.compareClassesWithResult(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass fieldTypeCtClass = CtClassBuilder.create().name("japicmp.FieldType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtFieldBuilder.create().type(fieldTypeCtClass).name("field").addToClass(ctClass);
+				return Arrays.asList(fieldTypeCtClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass fieldTypeCtClass = CtClassBuilder.create().name("japicmp.FieldType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtFieldBuilder.create().type(classPool.get("java.lang.String")).name("field").addToClass(ctClass);
+				return Arrays.asList(fieldTypeCtClass, ctClass);
+			}
+		});
+		options.addExcludeFromArgument(Optional.of("japicmp.FieldType"), false); // exclude japicmp.FieldType
+		options.setErrorOnBinaryIncompatibility(true);
+		options.setErrorOnSourceIncompatibility(true);
+		options.setErrorOnExclusionIncompatibility(breakBuildIfCausedByExclusion);
+		new IncompatibleErrorOutput(options, result.getjApiClasses(), result.getJarArchiveComparator()).generate();
+	}
+
+	@Test
+	public void testBreakBuildIfNecessaryInterfaceRemovedCausedByExclusionFalse() throws Exception {
+		testBreakBuildIfNecessaryInterfaceRemovedCausedByExclusion(false);
+	}
+
+	@Test(expected = JApiCmpException.class)
+	public void testBreakBuildIfNecessaryInterfaceRemovedCausedByExclusionTrue() throws Exception {
+		testBreakBuildIfNecessaryInterfaceRemovedCausedByExclusion(true);
+	}
+
+	private void testBreakBuildIfNecessaryInterfaceRemovedCausedByExclusion(boolean breakBuildIfCausedByExclusion) throws Exception {
+		Options options = Options.newDefault();
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = JarArchiveComparatorOptions.of(options);
+		ClassesHelper.CompareClassesResult result = ClassesHelper.compareClassesWithResult(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass interfaceCtClass = CtInterfaceBuilder.create().name("japicmp.ITest").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").implementsInterface(interfaceCtClass).addToClassPool(classPool);
+				return Arrays.asList(interfaceCtClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass interfaceCtClass = CtInterfaceBuilder.create().name("japicmp.ITest").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				return Arrays.asList(interfaceCtClass, ctClass);
+			}
+		});
+		options.addExcludeFromArgument(Optional.of("japicmp.ITest"), false); // exclude japicmp.ITest
+		options.setErrorOnBinaryIncompatibility(true);
+		options.setErrorOnSourceIncompatibility(true);
+		options.setErrorOnExclusionIncompatibility(breakBuildIfCausedByExclusion);
+		new IncompatibleErrorOutput(options, result.getjApiClasses(), result.getJarArchiveComparator()).generate();
+	}
+
+	@Test
+	public void testBreakBuildIfNecessaryMethodReturnTypeChangedCausedByExclusionFalse() throws Exception {
+		testBreakBuildIfNecessaryMethodReturnTypeChangedCausedByExclusion(false);
+	}
+
+	@Test(expected = JApiCmpException.class)
+	public void testBreakBuildIfNecessaryMethodReturnTypeChangedCausedByExclusionTrue() throws Exception {
+		testBreakBuildIfNecessaryMethodReturnTypeChangedCausedByExclusion(true);
+	}
+
+	private void testBreakBuildIfNecessaryMethodReturnTypeChangedCausedByExclusion(boolean breakBuildIfCausedByExclusion) throws Exception {
+		Options options = Options.newDefault();
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = JarArchiveComparatorOptions.of(options);
+		ClassesHelper.CompareClassesResult result = ClassesHelper.compareClassesWithResult(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass typeCtClass = CtClassBuilder.create().name("japicmp.MethodReturnType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().returnType(typeCtClass).name("test").addToClass(ctClass);
+				return Arrays.asList(typeCtClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass typeCtClass = CtClassBuilder.create().name("japicmp.MethodReturnType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().returnType(classPool.get("java.lang.String")).name("test").addToClass(ctClass);
+				return Arrays.asList(typeCtClass, ctClass);
+			}
+		});
+		options.addExcludeFromArgument(Optional.of("japicmp.MethodReturnType"), false); // exclude japicmp.MethodReturnType
+		options.setErrorOnBinaryIncompatibility(true);
+		options.setErrorOnSourceIncompatibility(true);
+		options.setErrorOnExclusionIncompatibility(breakBuildIfCausedByExclusion);
+		new IncompatibleErrorOutput(options, result.getjApiClasses(), result.getJarArchiveComparator()).generate();
+	}
+
+	@Test
+	public void testBreakBuildIfNecessarySuperclassChangedCausedByExclusionFalse() throws Exception {
+		testBreakBuildIfNecessarySuperclassTypeChangedCausedByExclusion(false);
+	}
+
+	@Test(expected = JApiCmpException.class)
+	public void testBreakBuildIfNecessarySuperclassTypeChangedCausedByExclusionTrue() throws Exception {
+		testBreakBuildIfNecessarySuperclassTypeChangedCausedByExclusion(true);
+	}
+
+	private void testBreakBuildIfNecessarySuperclassTypeChangedCausedByExclusion(boolean breakBuildIfCausedByExclusion) throws Exception {
+		Options options = Options.newDefault();
+		JarArchiveComparatorOptions jarArchiveComparatorOptions = JarArchiveComparatorOptions.of(options);
+		ClassesHelper.CompareClassesResult result = ClassesHelper.compareClassesWithResult(jarArchiveComparatorOptions, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass typeCtClass = CtClassBuilder.create().name("japicmp.SuperType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").withSuperclass(typeCtClass).addToClassPool(classPool);
+				return Arrays.asList(typeCtClass, ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass typeCtClass = CtClassBuilder.create().name("japicmp.SuperType").addToClassPool(classPool);
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").withSuperclass(classPool.get("java.lang.String")).addToClassPool(classPool);
+				return Arrays.asList(typeCtClass, ctClass);
+			}
+		});
+		options.addExcludeFromArgument(Optional.of("japicmp.SuperType"), false); // exclude japicmp.SuperType
+		options.setErrorOnBinaryIncompatibility(true);
+		options.setErrorOnSourceIncompatibility(true);
+		options.setErrorOnExclusionIncompatibility(breakBuildIfCausedByExclusion);
+		new IncompatibleErrorOutput(options, result.getjApiClasses(), result.getJarArchiveComparator()).generate();
+	}
+
+	// TODO Test with missing versions
+}

--- a/japicmp/src/test/java/japicmp/util/Helper.java
+++ b/japicmp/src/test/java/japicmp/util/Helper.java
@@ -33,8 +33,17 @@ public class Helper {
 		return toJApiCmpArchive(file);
 	}
 
+	public static JApiCmpArchive getArchive(String filename, String version) {
+		File file = new File("target" + File.separator + filename);
+		return toJApiCmpArchive(file, version);
+	}
+
 	public static JApiCmpArchive toJApiCmpArchive(File file) {
 		return new JApiCmpArchive(file, "n.a.");
+	}
+
+	public static JApiCmpArchive toJApiCmpArchive(File file, String version) {
+		return new JApiCmpArchive(file, version);
 	}
 
 	public static JApiClass getJApiClass(List<JApiClass> jApiClasses, String fqn) {

--- a/src/site/markdown/AntTask.md
+++ b/src/site/markdown/AntTask.md
@@ -64,4 +64,11 @@ The following table gives an overview of all available parameters of the Ant tas
 | xmlOutputFile 							| true  | n.a.  | Path to the xml output file. |
 | htmlOutputFile 							| true  | n.a.  | Path to the html output file. |
 | htmlStylesheet 							| true  | n.a.  | Path to your own stylesheet. |
+| errorOnBinaryIncompatibility				| true	| false | Exit with an error if a binary incompatibility is detected. |
+| errorOnSourceIncompatibility				| true	| false | Exit with an error if a source incompatibility is detected. |
+| errorOnModifications						| true	| false | Exit with an error if any change between versions is detected. |
+| errorOnExclusionIncompatibility			| true	| false | Ignore incompatible changes caused by an excluded class. |
+| errorOnSemanticIncompatibility 			| true	| false | Exit with an error if the binary compatibility changes are inconsistent with Semantic Versioning. This expects versions of the form Major.Minor.Patch (e.g. 1.2.3 or 1.2.3-SNAPSHOT). |
+| ignoreMissingOldVersion					| true	| false | When errorOnSemanticIncompatibility is true, ignore non-resolvable artifacts for the old version. |
+| ignoreMissingNewVersion					| true	| false | When errorOnSemanticIncompatibility is true, ignore non-resolvable artifacts for the new version. |
 

--- a/src/site/markdown/CliTool.md
+++ b/src/site/markdown/CliTool.md
@@ -17,6 +17,12 @@ SYNOPSIS
                 [--old-classpath <oldClassPath>] [--report-only-filename]
                 [(-s | --semantic-versioning)]
                 [(-x <pathToXmlOutputFile> | --xml-file <pathToXmlOutputFile>)]
+                [--error-on-binary-incompatibility]
+                [--error-on-source-incompatibility]
+                [--error-on-modifications]
+                [--no-error-on-exclusion-incompatibility]
+                [--error-on-semantic-incompatibility]
+                [--ignore-missing-old-version] [--ignore-missing-new-version]
 
 OPTIONS
         -a <accessModifier>
@@ -95,6 +101,35 @@ OPTIONS
 
         -x <pathToXmlOutputFile>, --xml-file <pathToXmlOutputFile>
             Provides the path to the xml output file.
+
+        --error-on-binary-incompatibility
+            Exit with an error if a binary incompatibility is detected.
+
+        --error-on-source-incompatibility
+            Exit with an error if a source incompatibility is detected.
+
+        --error-on-modifications
+            Exit with an error if any change between versions is detected.
+
+        --no-error-on-exclusion-incompatibility
+            Ignore incompatible changes caused by an excluded class
+            (e.g. excluded interface removed from not excluded class) when
+            deciding whether to exit with an error.
+
+        --error-on-semantic-incompatibility
+            Exit with an error if the binary compatibility changes are
+            inconsistent with Semantic Versioning. This expects versions of
+            the form Major.Minor.Patch (e.g. 1.2.3 or 1.2.3-SNAPSHOT).
+            See http://semver.org/spec/v2.0.0.html for more information about
+            Semantic Versioning.
+
+        --ignore-missing-old-version
+            When --error-on-semantic-incompatibility is passed, ignore
+            non-resolvable artifacts for the old version.
+
+        --ignore-missing-new-version
+            When --error-on-semantic-incompatibility is passed, ignore
+            non-resolvable artifacts for the new version.
 
 ```
 


### PR DESCRIPTION
Use case: I wanted to be able to detect incompatible changes from the japicmp API and/or CLI, as the maven plugin already supports. Is this approach is acceptable, I can add to the CLI tests for the new options, are currently this is only tested via the maven plugin tests.

* This takes the existing code from the Maven plugin and refactors it as an OutputGenerator<Void>.
* `IncompatibleErrorOutput.process()` throws a `JApiCmpException` is incompatibilities are detected.
* The JApiCmpException.reason is a new IncompatibleChange.
* Command line options are added to configure the output generator which runs last, so existing reports are
  still generated.
* The exception will propagate out of `JApiCmp`, given users of that API a way to know incompatible changes were detected.
* Similarly `JApiCmp.main()` will exit with status code 1
* The Maven plugin is refactored to:
    * Honour existing plugin configuration parameters
    * Use the new IncompatibleErrorOutput API
    * catch JApiCmpException with reason IncompatibleChange, and rethrow
      a MojoFailedException, preserving previous semantics.

