### PR TITLE
Fix missing numbers in major version number.

### DIFF
--- a/japicmp/src/main/java/japicmp/versioning/Version.java
+++ b/japicmp/src/main/java/japicmp/versioning/Version.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 public class Version {
 	private static final Logger LOGGER = Logger.getLogger(Version.class.getName());
-	private static final Pattern VERSION_PATTERN_THREE_DIGITS = Pattern.compile(".*([0-9]+)\\.([0-9]+)\\.([0-9]+).*");
+	private static final Pattern VERSION_PATTERN_THREE_DIGITS = Pattern.compile(".*?([0-9]+)\\.([0-9]+)\\.([0-9]+).*");
 	private final String version;
 
 	public Version(String version) {

--- a/japicmp/src/test/java/japicmp/util/VersionTest.java
+++ b/japicmp/src/test/java/japicmp/util/VersionTest.java
@@ -1,0 +1,37 @@
+package japicmp.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import japicmp.versioning.SemanticVersion;
+import japicmp.versioning.Version;
+
+public class VersionTest {
+
+	@Test
+	public void testSingleDigitSemanticVersionFromString() {
+		Optional<SemanticVersion> semver = Version.getSemanticVersion("1.2.3");
+		assertThat(semver.get().getMajor(), is(1));
+		assertThat(semver.get().getMinor(), is(2));
+		assertThat(semver.get().getPatch(), is(3));
+	}
+	
+	@Test
+	public void testMultidigitSemanticVersionFromString() {
+		Optional<SemanticVersion> semver = Version.getSemanticVersion("11.22.33");
+		assertThat(semver.get().getMajor(), is(11));
+		assertThat(semver.get().getMinor(), is(22));
+		assertThat(semver.get().getPatch(), is(33));
+	}
+	
+	@Test
+	public void testEmbeddedSemanticVersionFromString() {
+		Optional<SemanticVersion> semver = Version.getSemanticVersion("filename11.22.33filename");
+		assertThat(semver.get().getMajor(), is(11));
+		assertThat(semver.get().getMinor(), is(22));
+		assertThat(semver.get().getPatch(), is(33));
+	}
+
+}


### PR DESCRIPTION
I noticed that the major version may not be correctly extracted because it was using a greedy regex. I made the regex used here less greedy. 

When a multi digit major version is used it ends up with the last digit. If the last digit was 0 then this could effectively turn off semantic version checks and the following message can be seen:

[INFO] --- japicmp-maven-plugin:0.11.0:cmp (default) @ ImTransformer ---
[INFO] Written file '/awesomeproject/build/target/japicmp/japicmp.diff'.
[INFO] Skipping semantic version check because all major versions are zero (see http://semver.org/#semantic-versioning-specification-semver, section 4).
[INFO] ------------------------------------------------------------------------


