### PR TITLE
extractExceptions changes to prevent NPE

### DIFF
--- a/japicmp/src/main/java/japicmp/model/JApiBehavior.java
+++ b/japicmp/src/main/java/japicmp/model/JApiBehavior.java
@@ -95,9 +95,14 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 
 	private List<String> extractExceptions(Optional<? extends CtBehavior> methodOptional) {
 		if (methodOptional.isPresent()) {
-			ExceptionsAttribute exceptionsAttribute = methodOptional.get().getMethodInfo().getExceptionsAttribute();
+			ExceptionsAttribute exceptionsAttribute = null;
+			try {
+				exceptionsAttribute = methodOptional.get().getMethodInfo().getExceptionsAttribute();
+			} catch (NullPointerException ex) {
+				return Collections.emptyList();
+			}
 			String[] exceptions;
-			if (exceptionsAttribute != null) {
+			if (exceptionsAttribute != null && exceptionsAttribute.getExceptions() != null) {
 				exceptions = exceptionsAttribute.getExceptions();
 			} else {
 				exceptions = new String[0];


### PR DESCRIPTION
I received NPE when doing japicmp and WildFly experiments - https://github.com/rsvoboda/rsvoboda-playground/tree/master/japicmp-and-wildfly#generate-api-diff---custom-branch

I used temporary branch https://github.com/rsvoboda/japicmp/commit/7049ddbbbe10e7a335bece36541f415ace2ed447 to see where the troubles were, this is version without stdout stuff.

Just for the record, problematic stuff is javassist / undertow related:
```
exceptions == null - javassist.bytecode.ExceptionsAttribute@4ba6f55a - methodOptional: javassist.CtConstructor@4fa4e58f[public HttpRequestParser$$generated (Lorg/xnio/OptionMap;)V] - class: io.undertow.server.protocol.http.HttpRequestParser$$generated
exceptions == null - javassist.bytecode.ExceptionsAttribute@72044ee4 - methodOptional: javassist.CtConstructor@5de85f7[public HttpRequestParser$$generated (Lorg/xnio/OptionMap;)V] - class: io.undertow.server.protocol.http.HttpRequestParser$$generated
exceptions == null - javassist.bytecode.ExceptionsAttribute@50ca6d5 - methodOptional: javassist.CtConstructor@3c995d55[public HttpResponseParser$$generated ()V] - class: io.undertow.client.http.HttpResponseParser$$generated
exceptions == null - javassist.bytecode.ExceptionsAttribute@1bbdfae5 - methodOptional: javassist.CtConstructor@2e35670b[public HttpResponseParser$$generated ()V] - class: io.undertow.client.http.HttpResponseParser$$generated
``` 