### PR TITLE
213: Output of japicmp-maven-plugin improved

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -441,17 +441,17 @@ public class JApiCmpMojo extends AbstractMojo {
 							switch(semanticVersionLevel) {
 								case MAJOR:
 									if (changeType.ordinal() > ChangeType.MAJOR.ordinal()) {
-										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+										getLog().error("Incompatibility detected: Requires semantic version level " + semanticVersionLevel + ": " + change );
 									}
 									break;
 								case MINOR:
 									if (changeType.ordinal() > ChangeType.MINOR.ordinal()) {
-										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+										getLog().error("Incompatibility detected: Requires semantic version level  " + semanticVersionLevel + ": " + change );
 									}
 									break;
 								case PATCH:
 									if (changeType.ordinal() > ChangeType.PATCH.ordinal()) {
-										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+										getLog().error("Incompatibility detected: Requires semantic version level  " + semanticVersionLevel + ": " + change );
 									}
 									break;
 							    default:

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -16,6 +16,7 @@ import japicmp.output.xml.XmlOutputGenerator;
 import japicmp.output.xml.XmlOutputGeneratorOptions;
 import japicmp.util.Optional;
 import japicmp.versioning.SemanticVersion;
+import japicmp.versioning.SemanticVersion.ChangeType;
 import japicmp.versioning.VersionChange;
 import javassist.CtClass;
 import org.apache.maven.artifact.Artifact;
@@ -400,7 +401,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		}
 	}
 
-	private void breakBuildIfNecessary(List<JApiClass> jApiClasses, Parameter parameterParam, Options options, JarArchiveComparator jarArchiveComparator) throws MojoFailureException {
+	void breakBuildIfNecessary(List<JApiClass> jApiClasses, Parameter parameterParam, Options options, JarArchiveComparator jarArchiveComparator) throws MojoFailureException {
 		if (breakBuildOnModificationsParameter(parameterParam)) {
 			for (JApiClass jApiClass : jApiClasses) {
 				if (jApiClass.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
@@ -410,8 +411,8 @@ public class JApiCmpMojo extends AbstractMojo {
 		}
 		breakBuildIfNecessaryByApplyingFilter(jApiClasses, parameterParam, options, jarArchiveComparator);
 		if (breakBuildBasedOnSemanticVersioning(parameterParam)) {
-			boolean ignoreMissingOldVersion = "true".equalsIgnoreCase(parameter.getIgnoreMissingOldVersion() == null ? "false" : parameter.getIgnoreMissingOldVersion());
-			boolean ignoreMissingNewVersion = "true".equalsIgnoreCase(parameter.getIgnoreMissingNewVersion() == null ? "false" : parameter.getIgnoreMissingNewVersion());
+			boolean ignoreMissingOldVersion = "true".equalsIgnoreCase(parameterParam.getIgnoreMissingOldVersion() == null ? "false" : parameterParam.getIgnoreMissingOldVersion());
+			boolean ignoreMissingNewVersion = "true".equalsIgnoreCase(parameterParam.getIgnoreMissingNewVersion() == null ? "false" : parameterParam.getIgnoreMissingNewVersion());
 			List<SemanticVersion> oldVersions = new ArrayList<>();
 			List<SemanticVersion> newVersions = new ArrayList<>();
 			for (JApiCmpArchive file : options.getOldArchives()) {
@@ -430,8 +431,38 @@ public class JApiCmpMojo extends AbstractMojo {
 			if (!versionChange.isAllMajorVersionsZero()) {
 				Optional<SemanticVersion.ChangeType> changeTypeOptional = versionChange.computeChangeType();
 				if (changeTypeOptional.isPresent()) {
-					SemanticVersion.ChangeType changeType = changeTypeOptional.get();
-					SemverOut semverOut = new SemverOut(options, jApiClasses);
+					final SemanticVersion.ChangeType changeType = changeTypeOptional.get();
+
+
+					SemverOut semverOut = new SemverOut(options, jApiClasses, new SemverOut.Listener() {
+
+						public void onChange(JApiCompatibility change, JApiSemanticVersionLevel semanticVersionLevel)
+						{
+							switch(semanticVersionLevel) {
+								case MAJOR:
+									if (changeType.ordinal() > ChangeType.MAJOR.ordinal()) {
+										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+									}
+									break;
+								case MINOR:
+									if (changeType.ordinal() > ChangeType.MINOR.ordinal()) {
+										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+									}
+									break;
+								case PATCH:
+									if (changeType.ordinal() > ChangeType.PATCH.ordinal()) {
+										getLog().error("Incompatiblity detected: " + semanticVersionLevel + ": " + change );
+									}
+									break;
+							    default:
+							    	// Ignore
+							}
+						}
+
+					});
+
+
+
 					String semver = semverOut.generate();
 					if (changeType == SemanticVersion.ChangeType.MINOR && semver.equals("1.0.0")) {
 						throw new MojoFailureException("Versions of archives indicate a minor change but binary incompatible changes found.");

--- a/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
@@ -30,6 +30,23 @@ public class JApiAnnotation implements JApiHasChangeStatus, JApiCompatibility {
 		this.changeStatus = evaluateChangeStatus(changeStatus);
 	}
 
+
+	public String toString()
+	{
+		return "JApiAnnotation [fullyQualifiedName="
+			+ fullyQualifiedName
+			+ ", oldAnnotation="
+			+ oldAnnotation
+			+ ", newAnnotation="
+			+ newAnnotation
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ getCompatibilityChanges()
+			+ "]";
+	}
+
+
 	private void computeElements(List<JApiAnnotationElement> elements, Optional<Annotation> oldAnnotationOptional, Optional<Annotation> newAnnotationOptional) {
 		if (oldAnnotationOptional.isPresent() && newAnnotationOptional.isPresent()) {
 			Annotation oldAnnotation = oldAnnotationOptional.get();

--- a/japicmp/src/main/java/japicmp/model/JApiAnnotationElement.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAnnotationElement.java
@@ -24,6 +24,27 @@ public class JApiAnnotationElement implements JApiHasChangeStatus, JApiCompatibi
 		this.changeStatus = evaluateChangeStatus(changeStatus);
 	}
 
+
+
+
+	public String toString()
+	{
+		return "JApiAnnotationElement [name="
+			+ name
+			+ ", oldValue="
+			+ oldValue
+			+ ", newValue="
+			+ newValue
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ getCompatibilityChanges()
+			+ "]";
+	}
+
+
+
+
 	private JApiChangeStatus evaluateChangeStatus(JApiChangeStatus changeStatus) {
 		if (changeStatus == JApiChangeStatus.UNCHANGED) {
 			if (oldValue.isPresent() && newValue.isPresent()) {

--- a/japicmp/src/main/java/japicmp/model/JApiClass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClass.java
@@ -923,4 +923,18 @@ public class JApiClass implements JApiHasModifiers, JApiHasChangeStatus, JApiHas
 	public JApiClassFileFormatVersion getClassFileFormatVersion() {
 		return classFileFormatVersion;
 	}
+
+	public String toString()
+	{
+		return "JApiClass [fullyQualifiedName="
+			+ fullyQualifiedName
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ compatibilityChanges
+			+ "]";
+	}
+
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiClassFileFormatVersion.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClassFileFormatVersion.java
@@ -84,4 +84,23 @@ public class JApiClassFileFormatVersion implements JApiHasChangeStatus, JApiComp
 	public List<JApiCompatibilityChange> getCompatibilityChanges() {
 		return this.compatibilityChanges;
 	}
+
+	public String toString()
+	{
+		return "JApiClassFileFormatVersion [majorVersionOld="
+			+ majorVersionOld
+			+ ", minorVersionOld="
+			+ minorVersionOld
+			+ ", majorVersionNew="
+			+ majorVersionNew
+			+ ", minorVersionNew="
+			+ minorVersionNew
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ compatibilityChanges
+			+ "]";
+	}
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiConstructor.java
+++ b/japicmp/src/main/java/japicmp/model/JApiConstructor.java
@@ -25,4 +25,21 @@ public class JApiConstructor extends JApiBehavior {
 	public Optional<CtConstructor> getOldConstructor() {
 		return oldConstructor;
 	}
+
+	public String toString()
+	{
+		return "JApiConstructor [oldConstructor="
+			+ oldConstructor
+			+ ", newConstructor="
+			+ newConstructor
+			+ ", getNewConstructor()="
+			+ getNewConstructor()
+			+ ", getOldConstructor()="
+			+ getOldConstructor()
+			+ ", getCompatibilityChanges()="
+			+ getCompatibilityChanges()
+			+ "]";
+	}
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiField.java
+++ b/japicmp/src/main/java/japicmp/model/JApiField.java
@@ -357,4 +357,36 @@ public class JApiField implements JApiHasChangeStatus, JApiHasModifiers, JApiHas
 	public JApiClass getjApiClass() {
 		return jApiClass;
 	}
+
+	public String toString()
+	{
+		return "JApiField [changeStatus="
+			+ changeStatus
+			+ ", jApiClass="
+			+ jApiClass
+			+ ", oldFieldOptional="
+			+ oldFieldOptional
+			+ ", newFieldOptional="
+			+ newFieldOptional
+			+ ", annotations="
+			+ annotations
+			+ ", accessModifier="
+			+ accessModifier
+			+ ", staticModifier="
+			+ staticModifier
+			+ ", finalModifier="
+			+ finalModifier
+			+ ", transientModifier="
+			+ transientModifier
+			+ ", syntheticModifier="
+			+ syntheticModifier
+			+ ", syntheticAttribute="
+			+ syntheticAttribute
+			+ ", compatibilityChanges="
+			+ compatibilityChanges
+			+ ", type="
+			+ type
+			+ "]";
+	}
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
+++ b/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
@@ -81,4 +81,17 @@ public class JApiImplementedInterface implements JApiHasChangeStatus, JApiCompat
 	public CtClass getCtClass() {
 		return ctClass;
 	}
+
+	public String toString()
+	{
+		return "JApiImplementedInterface [fullyQualifiedName="
+			+ fullyQualifiedName
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ compatibilityChanges
+			+ "]";
+	}
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiMethod.java
+++ b/japicmp/src/main/java/japicmp/model/JApiMethod.java
@@ -1,6 +1,7 @@
 package japicmp.model;
 
 import japicmp.util.Optional;
+import japicmp.util.OptionalHelper;
 import japicmp.cmp.JarArchiveComparator;
 import japicmp.util.MethodDescriptorParser;
 import javassist.CtMethod;
@@ -126,4 +127,29 @@ public class JApiMethod extends JApiBehavior {
 	public JApiReturnType getReturnType() {
 		return returnType;
 	}
+
+	public String toString()
+	{
+		return "JApiMethod [oldMethod="
+			+ toString(oldMethod)
+			+ ", newMethod="
+			+ toString(newMethod)
+			+ ", returnType="
+			+ returnType
+			+ ", getCompatibilityChanges()="
+			+ getCompatibilityChanges()
+			+ "]";
+	}
+
+	public static String toString(Optional<CtMethod> method) {
+		if(method == null ) {
+			return OptionalHelper.N_A;
+		}
+		if(method.isPresent()) {
+			return method.get().getLongName();
+		}
+		return OptionalHelper.N_A;
+	}
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiReturnType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiReturnType.java
@@ -30,4 +30,18 @@ public class JApiReturnType {
 	public String getNewReturnType() {
 		return OptionalHelper.optionalToString(newReturnTypeOptional);
 	}
+
+	public String toString()
+	{
+		return "JApiReturnType [oldReturnTypeOptional="
+			+ oldReturnTypeOptional
+			+ ", newReturnTypeOptional="
+			+ newReturnTypeOptional
+			+ ", changeStatus="
+			+ changeStatus
+			+ "]";
+	}
+
+
+
 }

--- a/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
@@ -142,4 +142,30 @@ public class JApiSuperclass implements JApiHasChangeStatus, JApiCompatibility {
 	public JApiClass getJApiClassOwning() {
 		return jApiClass;
 	}
+
+	public String toString()
+	{
+		String oldSuperClass = "n.a.";
+		if(oldSuperclassOptional.isPresent()) {
+			oldSuperClass = oldSuperclassOptional.get().getName();
+		}
+		String newSuperClass = "n.a.";
+		if(newSuperclassOptional.isPresent()) {
+			newSuperClass = newSuperclassOptional.get().getName();
+		}
+
+		return "JApiSuperclass [jApiClass="
+			+ jApiClass
+			+ ", oldSuperclass="
+			+ oldSuperClass
+			+ ", newSuperclass="
+			+ newSuperClass
+			+ ", changeStatus="
+			+ changeStatus
+			+ ", compatibilityChanges="
+			+ compatibilityChanges
+			+ "]";
+	}
+
+
 }


### PR DESCRIPTION
o Implemented toString methods for all JApiCompatibility
o japicmp-maven-plugin writes now errors to the console if an incompatible change is detected