### PR TITLE
New default method should be binary compatible

### DIFF
--- a/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
+++ b/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
@@ -33,7 +33,7 @@ public enum JApiCompatibilityChange {
 	METHOD_ABSTRACT_ADDED_TO_CLASS(true, false, JApiSemanticVersionLevel.MINOR),
 	METHOD_ABSTRACT_ADDED_IN_SUPERCLASS(true, false, JApiSemanticVersionLevel.MINOR),
 	METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE(true, false, JApiSemanticVersionLevel.MINOR),
-	METHOD_NEW_DEFAULT(false, false, JApiSemanticVersionLevel.MAJOR),
+	METHOD_NEW_DEFAULT(true, false, JApiSemanticVersionLevel.MAJOR),
 	METHOD_ABSTRACT_NOW_DEFAULT(false, false, JApiSemanticVersionLevel.MAJOR),
 	FIELD_STATIC_AND_OVERRIDES_STATIC(false, false, JApiSemanticVersionLevel.MAJOR),
 	FIELD_LESS_ACCESSIBLE_THAN_IN_SUPERCLASS(false, false, JApiSemanticVersionLevel.MAJOR),

--- a/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
+++ b/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
@@ -1317,10 +1317,10 @@ public class CompatibilityChangesTest {
 		assertThat(jApiClass.isBinaryCompatible(), is(true));
 		assertThat(jApiClass.isSourceCompatible(), is(true));
 		jApiClass = getJApiClass(jApiClasses, "japicmp.Interface");
-		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
 		assertThat(jApiClass.isSourceCompatible(), is(false));
 		JApiMethod jApiMethod = getJApiMethod(jApiClass.getMethods(), "defaultMethod");
-		assertThat(jApiMethod.isBinaryCompatible(), is(false));
+		assertThat(jApiMethod.isBinaryCompatible(), is(true));
 		assertThat(jApiMethod.isSourceCompatible(), is(false));
 		assertThat(jApiMethod.getCompatibilityChanges(), hasItem(JApiCompatibilityChange.METHOD_NEW_DEFAULT));
 		assertThat(jApiMethod.getCompatibilityChanges(), not(hasItem(JApiCompatibilityChange.METHOD_ADDED_TO_INTERFACE)));

--- a/src/site/markdown/MavenPlugin.md
+++ b/src/site/markdown/MavenPlugin.md
@@ -265,7 +265,7 @@ for each check. This allows you to customize the following verifications:
 | METHOD_ABSTRACT_ADDED_TO_CLASS | true | false | MINOR |
 | METHOD_ABSTRACT_ADDED_IN_SUPERCLASS | true | false | MINOR |
 | METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE | true | false | MINOR |
-| METHOD_NEW_DEFAULT | false | false | MAJOR |
+| METHOD_NEW_DEFAULT | true | false | MAJOR |
 | METHOD_ABSTRACT_NOW_DEFAULT | false | false | MAJOR |
 | FIELD_STATIC_AND_OVERRIDES_STATIC | false | false | MAJOR |
 | FIELD_LESS_ACCESSIBLE_THAN_IN_SUPERCLASS | false | false | MAJOR |


### PR DESCRIPTION
According to Oracle's documentation on https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.5.6 adding a new default method should be binary compatible.