### PR TITLE
Teach japicmp about 'effectively final'

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -349,7 +349,8 @@ public class CompatibilityChanges {
 			}
 			// section 13.4.17 of "Java Language Specification" SE7
 			if (isNotPrivate(method) && method.getFinalModifier().hasChangedFromTo(FinalModifier.NON_FINAL, FinalModifier.FINAL)) {
-				if (!(method.getStaticModifier().getOldModifier().isPresent() && method.getStaticModifier().getOldModifier().get() == StaticModifier.STATIC)) {
+				if ((jApiClass.getFinalModifier().getOldModifier().isPresent() && jApiClass.getFinalModifier().getOldModifier().get() != FinalModifier.FINAL) &&
+					!(method.getStaticModifier().getOldModifier().isPresent() && method.getStaticModifier().getOldModifier().get() == StaticModifier.STATIC)) {
 					addCompatibilityChange(method, JApiCompatibilityChange.METHOD_NOW_FINAL);
 				}
 			}

--- a/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
+++ b/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
@@ -580,6 +580,33 @@ public class CompatibilityChangesTest {
 	}
 
 	@Test
+	public void testMethodRemainsEffectivelyFinal() throws Exception {
+		JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
+		options.setIncludeSynthetic(true);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(options, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").finalModifier().addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().returnType(CtClass.booleanType).name("effectivelyFinal").body("return true;").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").finalModifier().addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().finalMethod().returnType(CtClass.booleanType).name("effectivelyFinal").body("return true;").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "japicmp.Test");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		JApiMethod jApiMethod = getJApiMethod(jApiClass.getMethods(), "effectivelyFinal");
+		assertThat(jApiMethod.getCompatibilityChanges().size(), is(0));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+	}
+
+	@Test
 	public void testMethodNowStatic() throws Exception {
 		JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
 		options.setIncludeSynthetic(true);


### PR DESCRIPTION
The JLS section on final methods says this:

  "Changing an instance method that is not declared final to be declared
  final may break compatibility with existing binaries that depend on the
  ability to override the method."

If the enclosing class is final, existing binaries have no mechanism to override
the method, so the change does not break compatibility.

This is relevant for Java to Kotlin migrations as the Kotlin compiler adds the
'final' modifier to all methods of final classes, whereas the Java compiler does
exactly what is in source code.

Closes: https://github.com/siom79/japicmp/issues/206