### PR TITLE
resolves #240 allowing user properties

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -87,6 +87,20 @@ public class JApiCmpMojo extends AbstractMojo {
 	private List<Dependency> newClassPathDependencies;
 	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.skip", required = false)
 	private String skip;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.skipXmlReport", required = false)
+	private boolean skipXmlReport;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.skipHtmlReport", required = false)
+	private boolean skipHtmlReport;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.breakBuildOnModifications", required = false)
+	private boolean breakBuildOnModifications;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.breakBuildOnBinaryIncompatibleModifications", required = false)
+	private boolean breakBuildOnBinaryIncompatibleModifications;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.breakBuildOnSourceIncompatibleModifications", required = false)
+	private boolean breakBuildOnSourceIncompatibleModifications;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.breakBuildBasedOnSemanticVersioning", required = false)
+	private boolean breakBuildBasedOnSemanticVersioning;
+	@org.apache.maven.plugins.annotations.Parameter(property = "japicmp.breakBuildBasedOnSemanticVersioningForMajorVersionZero", required = false)
+	private boolean breakBuildBasedOnSemanticVersioningForMajorVersionZero;
 	@org.apache.maven.plugins.annotations.Parameter(property = "project.build.directory", required = true)
 	private File projectBuildDir;
 	@Component
@@ -445,9 +459,9 @@ public class JApiCmpMojo extends AbstractMojo {
 	private boolean breakBuildBasedOnSemanticVersioningForMajorVersionZero(Parameter parameterParam) {
 		boolean retVal = false;
 		if (parameter != null) {
-			retVal = Boolean.valueOf(parameter.isBreakBuildBasedOnSemanticVersioningForMajorVersionZero());
+			retVal = parameter.isBreakBuildBasedOnSemanticVersioningForMajorVersionZero();
 		}
-		return retVal;
+		return retVal || breakBuildBasedOnSemanticVersioningForMajorVersionZero;
 	}
 
 	Options getOptions(PluginParameters pluginParameters, MavenParameters mavenParameters) throws MojoFailureException {
@@ -524,7 +538,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (parameterParam != null) {
 			retVal = Boolean.valueOf(parameterParam.getBreakBuildOnModifications());
 		}
-		return retVal;
+		return retVal || breakBuildOnModifications;
 	}
 
 	private boolean breakBuildOnBinaryIncompatibleModifications(Parameter parameterParam) {
@@ -532,7 +546,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (parameterParam != null) {
 			retVal = Boolean.valueOf(parameterParam.getBreakBuildOnBinaryIncompatibleModifications());
 		}
-		return retVal;
+		return retVal || breakBuildOnBinaryIncompatibleModifications;
 	}
 
 	private boolean breakBuildOnSourceIncompatibleModifications(Parameter parameter) {
@@ -540,7 +554,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (parameter != null) {
 			retVal = Boolean.valueOf(parameter.getBreakBuildOnSourceIncompatibleModifications());
 		}
-		return retVal;
+		return retVal || breakBuildOnSourceIncompatibleModifications;
 	}
 
 	private boolean breakBuildBasedOnSemanticVersioning(Parameter parameter) {
@@ -548,7 +562,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (parameter != null) {
 			retVal = Boolean.valueOf(parameter.getBreakBuildBasedOnSemanticVersioning());
 		}
-		return retVal;
+		return retVal || breakBuildBasedOnSemanticVersioning;
 	}
 
 	private File createJapiCmpBaseDir(PluginParameters pluginParameters) throws MojoFailureException {
@@ -625,7 +639,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (pluginParameters.getParameterParam() != null) {
 			skipReport = Boolean.valueOf(pluginParameters.getParameterParam().getSkipHtmlReport());
 		}
-		return skipReport;
+		return skipReport || skipHtmlReport;
 	}
 
 	private boolean skipXmlReport(PluginParameters pluginParameters) {
@@ -633,7 +647,7 @@ public class JApiCmpMojo extends AbstractMojo {
 		if (pluginParameters.getParameterParam() != null) {
 			skipReport = Boolean.valueOf(pluginParameters.getParameterParam().getSkipXmlReport());
 		}
-		return skipReport;
+		return skipReport || skipXmlReport;
 	}
 
 	private String createFilename(MavenParameters mavenParameters) {

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
@@ -42,7 +42,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private List<Dependency> newClassPathDependencies;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String skip;
+	private boolean skip;
 	@org.apache.maven.plugins.annotations.Parameter(required = true, readonly = true, property = "project.reporting.outputDirectory")
 	private String outputDirectory;
 	@Component
@@ -69,7 +69,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 	protected void executeReport(Locale locale) throws MavenReportException {
 		try {
 			JApiCmpMojo mojo = getMojo();
-			if ("true".equalsIgnoreCase(skip) || isPomModuleNeedingSkip()) {
+			if (skip || isPomModuleNeedingSkip()) {
 				getLog().info("japicmp module set to skip");
 				return;
 			}
@@ -136,7 +136,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 	@Override
 	public String getDescription(Locale locale) {
 		getMojo();
-		if (Boolean.TRUE.toString().equalsIgnoreCase(skip) || isPomModuleNeedingSkip()) {
+		if (skip || isPomModuleNeedingSkip()) {
 			return "skipping report";
 		}
 		Options options = getOptions();
@@ -147,7 +147,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 	}
 
 	private boolean isPomModuleNeedingSkip() {
-		return Boolean.TRUE.toString().equalsIgnoreCase(pluginParameters.getParameterParam().getSkipPomModules())
+		return pluginParameters.getParameterParam().getSkipPomModules()
 			&& "pom".equalsIgnoreCase(mavenProject.getArtifact().getType());
 	}
 }

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/Parameter.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/Parameter.java
@@ -6,24 +6,24 @@ public class Parameter {
 	private String accessModifier;
 	private List<String> includes;
 	private List<String> excludes;
-	private String onlyBinaryIncompatible;
-	private String onlyModified;
-	private String breakBuildOnModifications;
-	private String breakBuildOnBinaryIncompatibleModifications;
-	private String breakBuildOnSourceIncompatibleModifications;
-	private String breakBuildBasedOnSemanticVersioning;
-	private String includeSynthetic;
-	private String ignoreMissingClasses;
+	private boolean onlyBinaryIncompatible;
+	private boolean onlyModified;
+	private boolean breakBuildOnModifications;
+	private boolean breakBuildOnBinaryIncompatibleModifications;
+	private boolean breakBuildOnSourceIncompatibleModifications;
+	private boolean breakBuildBasedOnSemanticVersioning;
+	private boolean includeSynthetic;
+	private boolean ignoreMissingClasses;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private List<String> ignoreMissingClassesByRegularExpressions;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String skipPomModules;
+	private boolean skipPomModules = true;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private String htmlStylesheet;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private String htmlTitle;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String noAnnotations;
+	private boolean noAnnotations;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private String ignoreNonResolvableArtifacts;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
@@ -31,15 +31,15 @@ public class Parameter {
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private String postAnalysisScript;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String skipHtmlReport;
+	private boolean skipHtmlReport;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String skipXmlReport;
+	private boolean skipXmlReport;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private boolean skipDiffReport;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String ignoreMissingOldVersion;
+	private boolean ignoreMissingOldVersion;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
-	private String ignoreMissingNewVersion;
+	private boolean ignoreMissingNewVersion;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
 	private String oldVersionPattern;
 	@org.apache.maven.plugins.annotations.Parameter(required = false)
@@ -106,11 +106,11 @@ public class Parameter {
 		}
 	}
 
-	public String getNoAnnotations() {
+	public boolean getNoAnnotations() {
 		return noAnnotations;
 	}
 
-	public void setNoAnnotations(String noAnnotations) {
+	public void setNoAnnotations(boolean noAnnotations) {
 		this.noAnnotations = noAnnotations;
 	}
 
@@ -122,43 +122,43 @@ public class Parameter {
 		this.accessModifier = accessModifier;
 	}
 
-	public String getOnlyModified() {
+	public boolean getOnlyModified() {
 		return onlyModified;
 	}
 
-	public void setOnlyModified(String onlyModified) {
+	public void setOnlyModified(boolean onlyModified) {
 		this.onlyModified = onlyModified;
 	}
 
-	public String getOnlyBinaryIncompatible() {
+	public boolean getOnlyBinaryIncompatible() {
 		return onlyBinaryIncompatible;
 	}
 
-	public void setOnlyBinaryIncompatible(String onlyBinaryIncompatible) {
+	public void setOnlyBinaryIncompatible(boolean onlyBinaryIncompatible) {
 		this.onlyBinaryIncompatible = onlyBinaryIncompatible;
 	}
 
-	public String getBreakBuildOnModifications() {
+	public boolean getBreakBuildOnModifications() {
 		return breakBuildOnModifications;
 	}
 
-	public void setBreakBuildOnModifications(String breakBuildOnModifications) {
+	public void setBreakBuildOnModifications(boolean breakBuildOnModifications) {
 		this.breakBuildOnModifications = breakBuildOnModifications;
 	}
 
-	public String getBreakBuildOnBinaryIncompatibleModifications() {
+	public boolean getBreakBuildOnBinaryIncompatibleModifications() {
 		return breakBuildOnBinaryIncompatibleModifications;
 	}
 
-	public void setBreakBuildOnBinaryIncompatibleModifications(String breakBuildOnBinaryIncompatibleModifications) {
+	public void setBreakBuildOnBinaryIncompatibleModifications(boolean breakBuildOnBinaryIncompatibleModifications) {
 		this.breakBuildOnBinaryIncompatibleModifications = breakBuildOnBinaryIncompatibleModifications;
 	}
 
-	public String getIncludeSynthetic() {
+	public boolean getIncludeSynthetic() {
 		return includeSynthetic;
 	}
 
-	public void setIncludeSynthetic(String includeSynthetic) {
+	public void setIncludeSynthetic(boolean includeSynthetic) {
 		this.includeSynthetic = includeSynthetic;
 	}
 
@@ -178,19 +178,19 @@ public class Parameter {
 		this.excludes = excludes;
 	}
 
-	public String getIgnoreMissingClasses() {
+	public boolean getIgnoreMissingClasses() {
 		return ignoreMissingClasses;
 	}
 
-	public void setIgnoreMissingClasses(String ignoreMissingClasses) {
+	public void setIgnoreMissingClasses(boolean ignoreMissingClasses) {
 		this.ignoreMissingClasses = ignoreMissingClasses;
 	}
 
-	public String getSkipPomModules() {
+	public boolean getSkipPomModules() {
 		return skipPomModules;
 	}
 
-	public void setSkipPomModules(String skipPomModules) {
+	public void setSkipPomModules(boolean skipPomModules) {
 		this.skipPomModules = skipPomModules;
 	}
 
@@ -226,19 +226,19 @@ public class Parameter {
 		this.packagingSupporteds = packagingSupporteds;
 	}
 
-	public String getBreakBuildOnSourceIncompatibleModifications() {
+	public boolean getBreakBuildOnSourceIncompatibleModifications() {
 		return breakBuildOnSourceIncompatibleModifications;
 	}
 
-	public void setBreakBuildOnSourceIncompatibleModifications(String breakBuildOnSourceIncompatibleModifications) {
+	public void setBreakBuildOnSourceIncompatibleModifications(boolean breakBuildOnSourceIncompatibleModifications) {
 		this.breakBuildOnSourceIncompatibleModifications = breakBuildOnSourceIncompatibleModifications;
 	}
 
-	public String getBreakBuildBasedOnSemanticVersioning() {
+	public boolean getBreakBuildBasedOnSemanticVersioning() {
 		return breakBuildBasedOnSemanticVersioning;
 	}
 
-	public void setBreakBuildBasedOnSemanticVersioning(String breakBuildBasedOnSemanticVersioning) {
+	public void setBreakBuildBasedOnSemanticVersioning(boolean breakBuildBasedOnSemanticVersioning) {
 		this.breakBuildBasedOnSemanticVersioning = breakBuildBasedOnSemanticVersioning;
 	}
 
@@ -250,19 +250,19 @@ public class Parameter {
 		this.postAnalysisScript = postAnalysisScript;
 	}
 
-	public String getSkipHtmlReport() {
+	public boolean getSkipHtmlReport() {
 		return skipHtmlReport;
 	}
 
-	public void setSkipHtmlReport(String skipHtmlReport) {
+	public void setSkipHtmlReport(boolean skipHtmlReport) {
 		this.skipHtmlReport = skipHtmlReport;
 	}
 
-	public String getSkipXmlReport() {
+	public boolean getSkipXmlReport() {
 		return skipXmlReport;
 	}
 
-	public void setSkipXmlReport(String skipXmlReport) {
+	public void setSkipXmlReport(boolean skipXmlReport) {
 		this.skipXmlReport = skipXmlReport;
 	}
 
@@ -274,11 +274,11 @@ public class Parameter {
 		this.skipDiffReport = skipDiffReport;
 	}
 
-	public String getIgnoreMissingOldVersion() {
+	public boolean getIgnoreMissingOldVersion() {
 		return ignoreMissingOldVersion;
 	}
 
-	public void setIgnoreMissingOldVersion(String ignoreMissingOldVersion) {
+	public void setIgnoreMissingOldVersion(boolean ignoreMissingOldVersion) {
 		this.ignoreMissingOldVersion = ignoreMissingOldVersion;
 	}
 
@@ -314,11 +314,11 @@ public class Parameter {
 		this.reportOnlyFilename = reportOnlyFileName;
 	}
 
-	public String getIgnoreMissingNewVersion() {
+	public boolean getIgnoreMissingNewVersion() {
 		return ignoreMissingNewVersion;
 	}
 
-	public void setIgnoreMissingNewVersion(String ignoreMissingNewVersion) {
+	public void setIgnoreMissingNewVersion(boolean ignoreMissingNewVersion) {
 		this.ignoreMissingNewVersion = ignoreMissingNewVersion;
 	}
 

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/PluginParameters.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/PluginParameters.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.util.List;
 
 public class PluginParameters {
-	private final String skipParam;
+	private final boolean skipParam;
 	private final Version oldVersionParam;
 	private final List<DependencyDescriptor> oldVersionsParam;
 	private final Version newVersionParam;
@@ -19,7 +19,7 @@ public class PluginParameters {
 	private final Optional<String> outputDirectory;
 	private final boolean writeToFiles;
 
-	public PluginParameters(String skipParam, Version newVersionParam, Version oldVersionParam, Parameter parameterParam, List<Dependency> dependenciesParam, Optional<File> projectBuildDirParam, Optional<String> outputDirectory, boolean writeToFiles, List<DependencyDescriptor> oldVersionsParam, List<DependencyDescriptor> newVersionsParam, List<Dependency> oldClassPathDependencies, List<Dependency> newClassPathDependencies) {
+	public PluginParameters(boolean skipParam, Version newVersionParam, Version oldVersionParam, Parameter parameterParam, List<Dependency> dependenciesParam, Optional<File> projectBuildDirParam, Optional<String> outputDirectory, boolean writeToFiles, List<DependencyDescriptor> oldVersionsParam, List<DependencyDescriptor> newVersionsParam, List<Dependency> oldClassPathDependencies, List<Dependency> newClassPathDependencies) {
 		this.skipParam = skipParam;
 		this.newVersionParam = newVersionParam;
 		this.oldVersionParam = oldVersionParam;
@@ -34,7 +34,7 @@ public class PluginParameters {
 		this.newVersionsParam = newVersionsParam;
 	}
 
-	public String getSkipParam() {
+	public boolean getSkipParam() {
 		return skipParam;
 	}
 

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/SkipModuleStrategy.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/SkipModuleStrategy.java
@@ -20,7 +20,7 @@ public class SkipModuleStrategy {
 	public boolean skip() {
 		MavenProject mavenProject = mavenParameters.getMavenProject();
 		Parameter parameterParam = pluginParameters.getParameterParam();
-		if (mavenProject != null && parameterParam !=null) {
+		if (mavenProject != null && parameterParam != null) {
 			List<String> packagingSupporteds = parameterParam.getPackagingSupporteds();
 			if ((packagingSupporteds != null) && !packagingSupporteds.isEmpty()) {
 				if (!packagingSupporteds.contains(mavenProject.getPackaging())) {
@@ -31,11 +31,7 @@ public class SkipModuleStrategy {
 				this.log.debug("No packaging support defined, no filtering");
 			}
 			if ("pom".equals(mavenProject.getPackaging())) {
-				boolean skipPomModules = true;
-				String skipPomModulesAsString = parameterParam.getSkipPomModules();
-				if (skipPomModulesAsString != null) {
-					skipPomModules = Boolean.valueOf(skipPomModulesAsString);
-				}
+				boolean skipPomModules = parameterParam.getSkipPomModules();
 				if (skipPomModules) {
 					this.log.info("Skipping execution because packaging of this module is 'pom'.");
 					return true;

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/VersionChange.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/VersionChange.java
@@ -25,14 +25,14 @@ public class VersionChange {
 
 	public Optional<SemanticVersion.ChangeType> computeChangeType() throws MojoFailureException {
 		if (this.oldArchives.isEmpty()) {
-			if (!"true".equalsIgnoreCase(this.parameter != null ? this.parameter.getIgnoreMissingOldVersion() : "false")) {
+			if (!(parameter != null && parameter.getIgnoreMissingOldVersion())) {
 				throw new MojoFailureException("Please provide at least one old version.");
 			} else {
 				return Optional.absent();
 			}
 		}
 		if (this.newArchives.isEmpty()) {
-			if (!"true".equalsIgnoreCase(this.parameter != null ? this.parameter.getIgnoreMissingNewVersion() : "false")) {
+			if (!(parameter != null && parameter.getIgnoreMissingNewVersion())) {
 				throw new MojoFailureException("Please provide at least one new version.");
 			} else {
 				return Optional.absent();

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
@@ -51,7 +51,7 @@ public class JApiCmpMojoTest {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");
-		PluginParameters pluginParameters = new PluginParameters(null, newVersion, oldVersion, new Parameter(), null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", "simple").toFile()), Optional.<String>absent(), true, null, null, null, null);
+		PluginParameters pluginParameters = new PluginParameters(false, newVersion, oldVersion, new Parameter(), null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", "simple").toFile()), Optional.<String>absent(), true, null, null, null, null);
 		ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
 		ArtifactResolutionResult artifactResolutionResult = mock(ArtifactResolutionResult.class);
 		Set<Artifact> artifactSet = new HashSet<>();
@@ -62,7 +62,10 @@ public class JApiCmpMojoTest {
 		when(artifactResolver.resolve(Matchers.<ArtifactResolutionRequest>anyObject())).thenReturn(artifactResolutionResult);
 		ArtifactFactory artifactFactory = mock(ArtifactFactory.class);
 		when(artifactFactory.createArtifactWithClassifier(eq("groupId"), eq("artifactId"), eq("0.1.1"), anyString(), anyString())).thenReturn(mock(Artifact.class));
-		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mock(MavenProject.class), mock(MojoExecution.class), "0.0.1", mock(ArtifactMetadataSource.class));
+		MavenProject mavenProject = mock(MavenProject.class);
+		when(mavenProject.getArtifact()).thenReturn(mock(Artifact.class));
+		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mavenProject, mock(MojoExecution.class), "0.0.1", mock(ArtifactMetadataSource.class));
+
 		mojo.executeWithParameters(pluginParameters, mavenParameters);
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", "simple", "japicmp", "japicmp.diff")), is(true));
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", "simple", "japicmp", "japicmp.xml")), is(true));
@@ -75,11 +78,11 @@ public class JApiCmpMojoTest {
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");
 		Parameter parameter = new Parameter();
-		parameter.setSkipHtmlReport("true");
-		parameter.setSkipXmlReport("true");
+		parameter.setSkipHtmlReport(true);
+		parameter.setSkipXmlReport(true);
 		parameter.setSkipDiffReport(true);
 		String reportDir = "noXmlAndNoHtmlNoDiffReport";
-		PluginParameters pluginParameters = new PluginParameters(null, newVersion, oldVersion, parameter, null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", reportDir).toFile()), Optional.<String>absent(), true, null, null, null, null);
+		PluginParameters pluginParameters = new PluginParameters(false, newVersion, oldVersion, parameter, null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", reportDir).toFile()), Optional.<String>absent(), true, null, null, null, null);
 		ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
 		ArtifactResolutionResult artifactResolutionResult = mock(ArtifactResolutionResult.class);
 		Set<Artifact> artifactSet = new HashSet<>();
@@ -90,7 +93,9 @@ public class JApiCmpMojoTest {
 		when(artifactResolver.resolve(Matchers.<ArtifactResolutionRequest>anyObject())).thenReturn(artifactResolutionResult);
 		ArtifactFactory artifactFactory = mock(ArtifactFactory.class);
 		when(artifactFactory.createArtifactWithClassifier(eq("groupId"), eq("artifactId"), eq("0.1.1"), anyString(), anyString())).thenReturn(mock(Artifact.class));
-		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mock(MavenProject.class), mock(MojoExecution.class), "0.0.1", mock(ArtifactMetadataSource.class));
+		MavenProject mavenProject = mock(MavenProject.class);
+		when(mavenProject.getArtifact()).thenReturn(mock(Artifact.class));
+		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mavenProject, mock(MojoExecution.class), "0.0.1", mock(ArtifactMetadataSource.class));
 		mojo.executeWithParameters(pluginParameters, mavenParameters);
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", reportDir, "japicmp", "japicmp.diff")), is(false));
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", reportDir, "japicmp", "japicmp.xml")), is(false));
@@ -139,8 +144,8 @@ public class JApiCmpMojoTest {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Parameter parameterParam = new Parameter();
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
-		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
-		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
+		parameterParam.setBreakBuildOnBinaryIncompatibleModifications(true);
+		parameterParam.setBreakBuildOnSourceIncompatibleModifications(true);
 		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, new JarArchiveComparator(jarArchiveComparatorOptions));
 	}
 
@@ -178,8 +183,8 @@ public class JApiCmpMojoTest {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Parameter parameterParam = new Parameter();
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
-		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
-		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
+		parameterParam.setBreakBuildOnBinaryIncompatibleModifications(true);
+		parameterParam.setBreakBuildOnSourceIncompatibleModifications(true);
 		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
@@ -217,8 +222,8 @@ public class JApiCmpMojoTest {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Parameter parameterParam = new Parameter();
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
-		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
-		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
+		parameterParam.setBreakBuildOnBinaryIncompatibleModifications(true);
+		parameterParam.setBreakBuildOnSourceIncompatibleModifications(true);
 		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
@@ -254,8 +259,8 @@ public class JApiCmpMojoTest {
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Parameter parameterParam = new Parameter();
 		parameterParam.setBreakBuildIfCausedByExclusion(breakBuildIfCausedByExclusion); //do not break the build if cause is excluded
-		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
-		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
+		parameterParam.setBreakBuildOnBinaryIncompatibleModifications(true);
+		parameterParam.setBreakBuildOnSourceIncompatibleModifications(true);
 		mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 	}
 
@@ -281,8 +286,8 @@ public class JApiCmpMojoTest {
 		});
 		JApiCmpMojo mojo = new JApiCmpMojo();
 		Parameter parameterParam = new Parameter();
-		parameterParam.setBreakBuildOnBinaryIncompatibleModifications("true");
-		parameterParam.setBreakBuildOnSourceIncompatibleModifications("true");
+		parameterParam.setBreakBuildOnBinaryIncompatibleModifications(true);
+		parameterParam.setBreakBuildOnSourceIncompatibleModifications(true);
 		try {
 			mojo.breakBuildIfNecessary(compareClassesResult.getjApiClasses(), parameterParam, options, compareClassesResult.getJarArchiveComparator());
 			fail("No exception thrown.");
@@ -301,9 +306,9 @@ public class JApiCmpMojoTest {
 		Version oldVersion = createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = createVersion("groupId", "artifactId", "0.1.1");
 		Parameter parameterParam = new Parameter();
-		parameterParam.setIgnoreMissingNewVersion("true");
-		parameterParam.setIgnoreMissingOldVersion("true");
-		PluginParameters pluginParameters = new PluginParameters(null, newVersion, oldVersion, parameterParam, null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", "simple").toFile()), Optional.<String>absent(), true, null, null, null, null);
+		parameterParam.setIgnoreMissingNewVersion(true);
+		parameterParam.setIgnoreMissingOldVersion(true);
+		PluginParameters pluginParameters = new PluginParameters(false, newVersion, oldVersion, parameterParam, null, Optional.of(Paths.get(System.getProperty("user.dir"), "target", "simple").toFile()), Optional.<String>absent(), true, null, null, null, null);
 		ArtifactResolver artifactResolver = mock(ArtifactResolver.class);
 		ArtifactResolutionResult artifactResolutionResult = mock(ArtifactResolutionResult.class);
 		Set<Artifact> artifactSet = new HashSet<>();
@@ -314,7 +319,9 @@ public class JApiCmpMojoTest {
 		MojoExecution mojoExecution = mock(MojoExecution.class);
 		String executionId = "ignoreMissingVersions";
 		when(mojoExecution.getExecutionId()).thenReturn(executionId);
-		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mock(MavenProject.class), mojoExecution, "0.0.1", mock(ArtifactMetadataSource.class));
+		MavenProject mavenProject = mock(MavenProject.class);
+		when(mavenProject.getArtifact()).thenReturn(mock(Artifact.class));
+		MavenParameters mavenParameters = new MavenParameters(new ArrayList<ArtifactRepository>(), artifactFactory, mock(ArtifactRepository.class), artifactResolver, mavenProject, mojoExecution, "0.0.1", mock(ArtifactMetadataSource.class));
 		mojo.executeWithParameters(pluginParameters, mavenParameters);
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", "simple", "japicmp", executionId + ".diff")), is(false));
 		assertThat(Files.exists(Paths.get(System.getProperty("user.dir"), "target", "simple", "japicmp", executionId + ".xml")), is(false));

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
@@ -98,7 +98,7 @@ public class SkipModuleStrategyTest {
 		Version oldVersion = JApiCmpMojoTest.createVersion("groupId", "artifactId", "0.1.0");
 		Version newVersion = JApiCmpMojoTest.createVersion("groupId", "artifactId", "0.1.1");
 		Parameter parameter = new Parameter();
-		return new PluginParameters("false", newVersion, oldVersion, parameter, new ArrayList<Dependency>(),
+		return new PluginParameters(false, newVersion, oldVersion, parameter, new ArrayList<Dependency>(),
 			Optional.<File>absent(), Optional.<String>absent(), false, new ArrayList<DependencyDescriptor>(),
 			new ArrayList<DependencyDescriptor>(), new ArrayList<Dependency>(), new ArrayList<Dependency>());
 	}

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/VersionChangeTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/VersionChangeTest.java
@@ -92,7 +92,7 @@ public class VersionChangeTest {
 	@Test
 	public void testMissingOldVersion() throws MojoFailureException {
 		Parameter parameter = new Parameter();
-		parameter.setIgnoreMissingOldVersion("true");
+		parameter.setIgnoreMissingOldVersion(true);
 		VersionChange vc = new VersionChange(Collections.singletonList(new JApiCmpArchive(new File("lib-1.2.3.jar"), "1.2.3")), Collections.singletonList(new JApiCmpArchive(new File("lib-1.2.3.jar"), "1.2.3")), parameter);
 		assertThat(vc.computeChangeType().get(), is(SemanticVersion.ChangeType.UNCHANGED));
 	}
@@ -100,7 +100,7 @@ public class VersionChangeTest {
 	@Test
 	public void testMissingNewVersion() throws MojoFailureException {
 		Parameter parameter = new Parameter();
-		parameter.setIgnoreMissingNewVersion("true");
+		parameter.setIgnoreMissingNewVersion(true);
 		VersionChange vc = new VersionChange(Collections.singletonList(new JApiCmpArchive(new File("lib-1.2.3.jar"), "1.2.3")), Collections.singletonList(new JApiCmpArchive(new File("lib-1.2.3.jar"), "1.2.3")), parameter);
 		assertThat(vc.computeChangeType().get(), is(SemanticVersion.ChangeType.UNCHANGED));
 	}

--- a/japicmp-testbase/japicmp-test-maven-plugin-userproperty/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-userproperty/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.github.siom79.japicmp</groupId>
+		<artifactId>japicmp-testbase</artifactId>
+		<version>0.14.2-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>japicmp-test-maven-plugin-userproperty</artifactId>
+
+	<properties>
+		<japicmp.skipXmlReport>true</japicmp.skipXmlReport>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.github.siom79.japicmp</groupId>
+			<artifactId>japicmp-maven-plugin</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>${project.version}</version>
+				<configuration>
+					<oldVersion>
+						<dependency>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp</artifactId>
+							<version>0.6.0</version>
+						</dependency>
+					</oldVersion>
+					<newVersion>
+						<dependency>
+							<groupId>com.github.siom79.japicmp</groupId>
+							<artifactId>japicmp</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</newVersion>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/japicmp-testbase/japicmp-test-maven-plugin-userproperty/src/test/java/japicmp/test/ITSkipped.java
+++ b/japicmp-testbase/japicmp-test-maven-plugin-userproperty/src/test/java/japicmp/test/ITSkipped.java
@@ -1,0 +1,22 @@
+package japicmp.test;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ITSkipped {
+
+	@Test
+	public void testSkipViaUserProperty() throws IOException {
+		Path xmlPath = Paths.get(System.getProperty("user.dir"), "target", "japicmp", "japicmp.xml");
+		assertThat(Files.exists(xmlPath), is(false));
+		Path htmlPath = Paths.get(System.getProperty("user.dir"), "target", "japicmp", "japicmp.html");
+		assertThat(Files.exists(htmlPath), is(true));
+	}
+}

--- a/japicmp-testbase/pom.xml
+++ b/japicmp-testbase/pom.xml
@@ -25,6 +25,7 @@
 		<module>japicmp-test-vx-client</module>
 		<module>japicmp-test-maven-plugin-ignoremissingartifact</module>
 		<module>japicmp-test-maven-plugin-packaging</module>
+		<module>japicmp-test-maven-plugin-userproperty</module>
 		<module>japicmp-test-ant-task</module>
 	</modules>
 


### PR DESCRIPTION
Adds ability to set certain break and skip parameter settings via `<properties>` section in pom OR via command-line, e.g.: `mvn clean verify -Djapicmp.skipXmlReport`