### PR TITLE
[OutputFilter] Do not filter out classes that are MODIFIED from the final report when using 'outputOnlyModifications'

### DIFF
--- a/japicmp/src/main/java/japicmp/output/OutputFilter.java
+++ b/japicmp/src/main/java/japicmp/output/OutputFilter.java
@@ -177,14 +177,6 @@ public class OutputFilter extends Filter {
 				if (!ModifierHelper.matchesModifierLevel(jApiClass, OutputFilter.this.options.getAccessModifier())) {
 					remove = true;
 				}
-				if (jApiClass.getChangeStatus() == JApiChangeStatus.MODIFIED) {
-					if (options.getAccessModifier().getLevel() > AccessModifier.PRIVATE.getLevel() && options.isOutputOnlyModifications()) {
-						ImmutableList<Boolean> list = findOneChangedElement(jApiClass);
-						if (list.isEmpty()) { //filter out this class if it does not have any changed element at this filter level
-							remove = true;
-						}
-					}
-				}
 				if (jApiClass.getJavaObjectSerializationCompatible().isIncompatible()) {
 					remove = false;
 				}


### PR DESCRIPTION
This PR attempts to address #247: if a class has been marked as MODIFIED, it should be part of the final report even if outputOnlyModifications has been set, regardless of whether its nested elements are marked as `MODIFIED'.

The tests run fine with this change. However, I did not find the right place to add a unit test for this.