### PR TITLE
Fix build when run concurrently.

### DIFF
--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -32,6 +32,12 @@
 			<artifactId>japicmp-maven-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.siom79.japicmp</groupId>
+			<artifactId>japicmp-test-v2</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/japicmp-testbase/japicmp-test-vx-client/pom.xml
+++ b/japicmp-testbase/japicmp-test-vx-client/pom.xml
@@ -19,6 +19,12 @@
 			<artifactId>${japicmp-test-vx.artifactId}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.siom79.japicmp</groupId>
+			<artifactId>japicmp-test-v2</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/japicmp-testbase/japicmp-testbundle-v1/pom.xml
+++ b/japicmp-testbase/japicmp-testbundle-v1/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.siom79.japicmp</groupId>
 		<artifactId>japicmp-testbase</artifactId>
-		<version>0.15.4-SNAPSHOT</version>
+		<version>0.15.5-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>japicmp-testbundle-v1</artifactId>

--- a/japicmp-testbase/japicmp-testbundle-v2/pom.xml
+++ b/japicmp-testbase/japicmp-testbundle-v2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.siom79.japicmp</groupId>
 		<artifactId>japicmp-testbase</artifactId>
-		<version>0.15.4-SNAPSHOT</version>
+		<version>0.15.5-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>japicmp-testbundle-v2</artifactId>


### PR DESCRIPTION
Fix failure when running concurrent Maven build. The modules copy the dependencies using `maven-dependency-plugin:copy` but as they are not specified as dependencies, Maven doesn't ensure they are build before this goal runs.

Also noticed that 2 of the POMs had incorrect versions.