### PR TITLE
Fix resolution of artifact to compare for ejb packaging

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -214,7 +214,7 @@ public class JApiCmpMojo extends AbstractMojo {
 
     private static DefaultArtifact createDefaultArtifact(String groupId, String artifactId, String classifier, String type, String version) {
         String mappedType = type;
-        if("bundle".equals(type)) {
+        if("bundle".equals(type) || "ejb".equals(type)) {
             mappedType ="jar";
         }
         DefaultArtifact artifactVersion = new DefaultArtifact(groupId, artifactId, classifier, mappedType,


### PR DESCRIPTION
Similar to #292, artifacts for `ejb` packaging should resolve to a `jar` extension.