### PR TITLE
[JAPICMP-307] Add add-opens to fix build under jdkk17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,7 @@
 						<configuration>
 							<argLine>
 								--illegal-access=warn
+								--add-opens java.base/java.lang=ALL-UNNAMED
 							</argLine>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
The PR adds `--add-opens java.base/java.lang=ALL-UNNAMED` to fix build with jdk17
fixes #307 