### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+
+    name: Release to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Maven Central
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Publish to Maven Central
+        run: |
+          git config user.name '${{ github.actor }}'
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          mvn -B release:prepare release:perform -Dpassword=${{ secrets.GITHUB_TOKEN }}
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -222,11 +222,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <remoteTagging>false</remoteTagging>
                     <suppressCommitBeforeTag>false</suppressCommitBeforeTag>
-					<goals>deploy</goals>
                 </configuration>
             </plugin>
             <plugin>
@@ -330,7 +328,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>3.0.0-M1</version>
+					<version>2.5.3</version>
 					<configuration>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<useReleaseProfile>false</useReleaseProfile>
@@ -343,9 +341,9 @@
     </build>
 
     <scm>
-        <connection>scm:git:git@github.com:${github.account}/${github.project}.git</connection>
-        <developerConnection>scm:git:git@github.com:${github.account}/${github.project}.git</developerConnection>
-        <url>git@github.com:${github.account}/${github.project}.git</url>
+        <connection>scm:git:https://github.com/${github.account}/${github.project}.git</connection>
+        <developerConnection>scm:git:https://github.com/${github.account}/${github.project}.git</developerConnection>
+        <url>https://github.com/${github.account}/${github.project}.git</url>
       <tag>HEAD</tag>
   </scm>
 
@@ -367,33 +365,6 @@
 	</distributionManagement>
 
     <profiles>
-        <profile>
-            <id>sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
            <id>doclint-java8-disabled</id>
            <activation>
@@ -518,7 +489,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.1</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -526,6 +497,12 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
Once merged, the release can be triggered via [manual action](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) under the [workflow page](https://github.com/siom79/japicmp/actions/workflows/release.yml).

The version should be set before triggering the release as no special parameter is exposed (the released version will be the one set in the POM and the next development version will have the patch number increased).

The following secrets should be added to the [repository configuration](https://github.com/siom79/japicmp/settings/secrets/actions):

* `GPG_PASSPHRASE`
* `GPG_PRIVATE_KEY`
* `OSSRH_TOKEN`
* `OSSRH_USERNAME`
