### PR TITLE
Update Maven build and plugin

### DIFF
--- a/japicmp-maven-plugin/pom.xml
+++ b/japicmp-maven-plugin/pom.xml
@@ -25,32 +25,32 @@
 	</licenses>
 
 	<properties>
-		<maven.version>3.6.3</maven.version>
-		<resolver.version>1.4.1</resolver.version> <!-- Sync to maven version -->
+		<mavenVersion>3.6.3</mavenVersion> <!-- maven.version property is reserved! -->
+		<resolver.version>1.4.1</resolver.version> <!-- keep in sync with maven version -->
 		<maven-plugin.version>3.6.4</maven-plugin.version>
 	</properties>
 
 	<prerequisites>
-		<maven>${maven.version}</maven>
+		<maven>${mavenVersion}</maven>
 	</prerequisites>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven.version}</version>
+			<version>${mavenVersion}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
+			<version>${mavenVersion}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>${maven.version}</version>
+			<version>${mavenVersion}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/japicmp-maven-plugin/pom.xml
+++ b/japicmp-maven-plugin/pom.xml
@@ -25,45 +25,63 @@
 	</licenses>
 
 	<properties>
-		<maven.version>3.6.0</maven.version>
-		<aether.version>1.1.0</aether.version>
+		<maven.version>3.6.3</maven.version>
+		<resolver.version>1.4.1</resolver.version> <!-- Sync to maven version -->
+		<maven-plugin.version>3.6.4</maven-plugin.version>
 	</properties>
 
 	<prerequisites>
-		<maven>3.0.3</maven>
+		<maven>${maven.version}</maven>
 	</prerequisites>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.6.3</version>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact</artifactId>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>
 			<artifactId>maven-resolver-api</artifactId>
-			<version>1.6.1</version>
+			<version>${resolver.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.6.0</version>
+			<version>${maven-plugin.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>2.2.1</version>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-api</artifactId>
-			<version>3.0</version>
+			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-impl</artifactId>
-			<version>3.0.0</version>
+			<version>3.1.0</version>
 			<exclusions>
+				<exclusion>
+					<groupId>org.codehaus.plexus</groupId>
+					<artifactId>plexus-container-default</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>xerces</groupId>
 					<artifactId>xercesImpl</artifactId>
@@ -87,7 +105,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>${maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>default-descriptor</id>
@@ -108,7 +126,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -140,20 +158,6 @@
 				</executions>
 			</plugin>
 		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-plugin-plugin</artifactId>
-					<version>3.6.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-site-plugin</artifactId>
-					<version>3.8.2</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<reporting>

--- a/japicmp-testbase/pom.xml
+++ b/japicmp-testbase/pom.xml
@@ -35,7 +35,7 @@
 	</modules>
 
 	<properties>
-		<maven.site.plugin.skip>true</maven.site.plugin.skip>
+		<maven.site.skip>true</maven.site.skip>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <github.account>siom79</github.account>
         <github.project>japicmp</github.project>
-		<maven.site.plugin.skip>false</maven.site.plugin.skip>
+		<maven.site.skip>false</maven.site.skip>
 		<surefireVersion>3.0.0-M7</surefireVersion>
 		<javassist.version>3.24.0-GA</javassist.version>
 		<guava.version>30.1-jre</guava.version>
@@ -322,9 +322,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.12.0</version>
-					<configuration>
-						<skip>${maven.site.plugin.skip}</skip>
-					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,143 +209,153 @@
 	</dependencyManagement>
 
     <build>
+		<extensions>
+			<extension>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-webdav-jackrabbit</artifactId>
+				<version>3.0.0</version>
+			</extension>
+		</extensions>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>${java.source}</source>
-                    <target>${java.target}</target>
-				</configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <remoteTagging>false</remoteTagging>
-                    <suppressCommitBeforeTag>false</suppressCommitBeforeTag>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                  <quiet>true</quiet>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
-            <plugin>
-                <!-- explicitly define maven-deploy-plugin after other to force exec order -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-                <executions>
-                    <execution>
-                        <id>deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>3.7.1</version>
-				<configuration>
-					<skip>${maven.site.plugin.skip}</skip>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.doxia</groupId>
-						<artifactId>doxia-module-markdown</artifactId>
-						<version>1.8</version>
-					</dependency>
-				</dependencies>
-			</plugin>
         </plugins>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>3.0.0</version>
-            </extension>
-        </extensions>
+
 		<pluginManagement>
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.22.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.2.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.1.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.0.2</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-war-plugin</artifactId>
-					<version>3.3.1</version>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
+					<configuration>
+						<source>${java.source}</source>
+						<target>${java.target}</target>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.0-M6</version>
 					<configuration>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<useReleaseProfile>false</useReleaseProfile>
 						<releaseProfiles>release</releaseProfiles>
 						<goals>deploy</goals>
+						<remoteTagging>false</remoteTagging>
+						<suppressCommitBeforeTag>false</suppressCommitBeforeTag>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.4.0</version>
+					<configuration>
+						<quiet>true</quiet>
+					</configuration>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.2.1</version>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar-no-fork</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<!-- explicitly define maven-deploy-plugin after other to force exec order -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.0.0-M2</version>
+					<executions>
+						<execution>
+							<id>deploy</id>
+							<phase>deploy</phase>
+							<goals>
+								<goal>deploy</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0-M7</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>3.0.0-M7</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>3.3.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.12.0</version>
+					<configuration>
+						<skip>${maven.site.plugin.skip}</skip>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.doxia</groupId>
+							<artifactId>doxia-module-markdown</artifactId>
+							<version>1.8</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.0.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>5.1.6</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
     </build>
 
-    <scm>
-        <connection>scm:git:https://github.com/${github.account}/${github.project}.git</connection>
-        <developerConnection>scm:git:https://github.com/${github.account}/${github.project}.git</developerConnection>
-        <url>https://github.com/${github.account}/${github.project}.git</url>
-      <tag>japicmp-base-0.15.7</tag>
-  </scm>
+	<scm>
+		<connection>scm:git:https://github.com/${github.account}/${github.project}.git</connection>
+		<developerConnection>scm:git:https://github.com/${github.account}/${github.project}.git</developerConnection>
+		<url>https://github.com/${github.account}/${github.project}.git</url>
+		<tag>japicmp-base-0.15.7</tag>
+	</scm>
 
 	<distributionManagement>
 		<site>
@@ -489,7 +499,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -132,12 +132,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <github.account>siom79</github.account>
         <github.project>japicmp</github.project>
-        <java.source>1.8</java.source>
-        <java.target>1.8</java.target>
 		<maven.site.plugin.skip>false</maven.site.plugin.skip>
+		<surefireVersion>3.0.0-M7</surefireVersion>
 		<javassist.version>3.24.0-GA</javassist.version>
 		<guava.version>30.1-jre</guava.version>
 		<jaxb.version>2.2.7</jaxb.version>
@@ -234,10 +235,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.10.1</version>
-					<configuration>
-						<source>${java.source}</source>
-						<target>${java.target}</target>
-					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -299,12 +296,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M7</version>
+					<version>${surefireVersion}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>3.0.0-M7</version>
+					<version>${surefireVersion}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -328,13 +325,6 @@
 					<configuration>
 						<skip>${maven.site.plugin.skip}</skip>
 					</configuration>
-					<dependencies>
-						<dependency>
-							<groupId>org.apache.maven.doxia</groupId>
-							<artifactId>doxia-module-markdown</artifactId>
-							<version>1.8</version>
-						</dependency>
-					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Changes:
* maven 3.6.0 is buggy, upped to latest 3.6.x (3.6.3)
* aligned resolver version with maven version
* using latest maven-plugin-plugin
* set provided scope for maven bits and resolver bits
* updated dependencies
* parent POM cleanup (upped plugin versions where applicable, added where missing), moved all to pluginMgmt

This results in "lighter" plugin, not only it does not download Maven 2 bits (maven-project???), but also will not re-download maven bits as they are now provided. Making the provided is possible with latest maven-plugin-plugin, that also emits warnings in build if maven bits not set to provided scope.