### PR TITLE
Drop Maven legacy (and unused bits) and reuse work done by Maven

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -679,13 +679,15 @@ public class JApiCmpMojo extends AbstractMojo {
 	}
 
 	private Set<Artifact> getCompileArtifacts(final MavenProject mavenProject) {
-		Set<org.apache.maven.artifact.Artifact> projectArtifacts = mavenProject.getArtifacts();
-		if ((projectArtifacts == null) || projectArtifacts.isEmpty()) {
-			return Collections.emptySet();
-		}
+		org.apache.maven.artifact.Artifact projectArtifact = mavenProject.getArtifact();
+		Set<org.apache.maven.artifact.Artifact> projectArtifacts = new HashSet<>();
+		projectArtifacts.add(projectArtifact);
+		projectArtifacts.addAll(mavenProject.getArtifacts());
 		HashSet<Artifact> result = new HashSet<>(projectArtifacts.size());
 		for (org.apache.maven.artifact.Artifact a : projectArtifacts) {
-			if (a.getArtifactHandler().isAddedToClasspath()) {
+			if (a == projectArtifact) {
+				result.add(RepositoryUtils.toArtifact(a)); // will have no scope, is distinguished
+			} else if (a.getArtifactHandler().isAddedToClasspath()) {
 				if (org.apache.maven.artifact.Artifact.SCOPE_COMPILE.equals(a.getScope())
 						|| org.apache.maven.artifact.Artifact.SCOPE_PROVIDED.equals(a.getScope())
 						|| org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(a.getScope())) {

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -678,15 +678,13 @@ public class JApiCmpMojo extends AbstractMojo {
 		comparatorOptions.getClassPathEntries().addAll(classPathEntries);
 	}
 
-	private Set<Artifact> getCompileArtifacts(final MavenProject mavenProject)
-	{
+	private Set<Artifact> getCompileArtifacts(final MavenProject mavenProject) {
 		Set<org.apache.maven.artifact.Artifact> projectArtifacts = mavenProject.getArtifacts();
 		if ((projectArtifacts == null) || projectArtifacts.isEmpty()) {
 			return Collections.emptySet();
 		}
 		HashSet<Artifact> result = new HashSet<>(projectArtifacts.size());
-		for (org.apache.maven.artifact.Artifact a : projectArtifacts)
-		{
+		for (org.apache.maven.artifact.Artifact a : projectArtifacts) {
 			if (a.getArtifactHandler().isAddedToClasspath()) {
 				if (org.apache.maven.artifact.Artifact.SCOPE_COMPILE.equals(a.getScope())
 						|| org.apache.maven.artifact.Artifact.SCOPE_PROVIDED.equals(a.getScope())

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -679,15 +679,11 @@ public class JApiCmpMojo extends AbstractMojo {
 	}
 
 	private Set<Artifact> getCompileArtifacts(final MavenProject mavenProject) {
-		org.apache.maven.artifact.Artifact projectArtifact = mavenProject.getArtifact();
-		Set<org.apache.maven.artifact.Artifact> projectArtifacts = new HashSet<>();
-		projectArtifacts.add(projectArtifact);
-		projectArtifacts.addAll(mavenProject.getArtifacts());
+		Set<org.apache.maven.artifact.Artifact> projectArtifacts = mavenProject.getArtifacts();
 		HashSet<Artifact> result = new HashSet<>(projectArtifacts.size());
+		result.add(RepositoryUtils.toArtifact(mavenProject.getArtifact())); // distinguished: the project artifact
 		for (org.apache.maven.artifact.Artifact a : projectArtifacts) {
-			if (a == projectArtifact) {
-				result.add(RepositoryUtils.toArtifact(a)); // will have no scope, is distinguished
-			} else if (a.getArtifactHandler().isAddedToClasspath()) {
+			if (a.getArtifactHandler().isAddedToClasspath()) {
 				if (org.apache.maven.artifact.Artifact.SCOPE_COMPILE.equals(a.getScope())
 						|| org.apache.maven.artifact.Artifact.SCOPE_PROVIDED.equals(a.getScope())
 						|| org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(a.getScope())) {

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -679,15 +679,15 @@ public class JApiCmpMojo extends AbstractMojo {
 	}
 
 	private Set<Artifact> getCompileArtifacts(final MavenProject mavenProject) {
-		Set<org.apache.maven.artifact.Artifact> projectArtifacts = mavenProject.getArtifacts();
-		HashSet<Artifact> result = new HashSet<>(projectArtifacts.size());
+		Set<org.apache.maven.artifact.Artifact> projectDependencies = mavenProject.getArtifacts(); // dependencies that this project has, including transitive ones
+		HashSet<Artifact> result = new HashSet<>(1 + projectDependencies.size());
 		result.add(RepositoryUtils.toArtifact(mavenProject.getArtifact())); // distinguished: the project artifact
-		for (org.apache.maven.artifact.Artifact a : projectArtifacts) {
-			if (a.getArtifactHandler().isAddedToClasspath()) {
-				if (org.apache.maven.artifact.Artifact.SCOPE_COMPILE.equals(a.getScope())
-						|| org.apache.maven.artifact.Artifact.SCOPE_PROVIDED.equals(a.getScope())
-						|| org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(a.getScope())) {
-					result.add(RepositoryUtils.toArtifact(a));
+		for (org.apache.maven.artifact.Artifact dep : projectDependencies) {
+			if (dep.getArtifactHandler().isAddedToClasspath()) {
+				if (org.apache.maven.artifact.Artifact.SCOPE_COMPILE.equals(dep.getScope())
+						|| org.apache.maven.artifact.Artifact.SCOPE_PROVIDED.equals(dep.getScope())
+						|| org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(dep.getScope())) {
+					result.add(RepositoryUtils.toArtifact(dep));
 				}
 			}
 		}

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
@@ -3,8 +3,6 @@ package japicmp.maven;
 import japicmp.config.Options;
 import japicmp.output.xml.XmlOutput;
 import japicmp.util.Optional;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.MojoExecution;
@@ -47,8 +45,6 @@ public class JApiCmpReport extends AbstractMavenReport {
 	@org.apache.maven.plugins.annotations.Parameter(required = true, readonly = true, property = "project.reporting.outputDirectory")
 	private String outputDirectory;
 	@Component
-	private ArtifactFactory artifactFactory;
-	@Component
 	private RepositorySystem repoSystem;
 	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
 	private RepositorySystemSession repoSession;
@@ -64,8 +60,6 @@ public class JApiCmpReport extends AbstractMavenReport {
 	private MojoExecution mojoExecution;
 	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "(,${project.version})", readonly = true)
 	private String versionRangeWithProjectVersion;
-	@Component
-	private ArtifactMetadataSource metadataSource;
 	private JApiCmpMojo mojo;
 	private MavenParameters mavenParameters;
 	private PluginParameters pluginParameters;
@@ -108,8 +102,8 @@ public class JApiCmpReport extends AbstractMavenReport {
 			return this.mojo;
 		}
 		this.mojo = new JApiCmpMojo();
-		this.mavenParameters = new MavenParameters(this.artifactRepositories, this.artifactFactory, this.localRepository,
-				this.mavenProject, this.mojoExecution, this.versionRangeWithProjectVersion, this.metadataSource, this.repoSystem, this.repoSession,
+		this.mavenParameters = new MavenParameters(this.artifactRepositories, this.localRepository,
+				this.mavenProject, this.mojoExecution, this.versionRangeWithProjectVersion, this.repoSystem, this.repoSession,
 				this.remoteRepos);
 		this.pluginParameters = new PluginParameters(this.skip, this.newVersion, this.oldVersion, this.parameter, this.dependencies, Optional.<File>absent(), Optional.of(
 				this.outputDirectory), false, this.oldVersions, this.newVersions, this.oldClassPathDependencies, this.newClassPathDependencies);

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
@@ -15,7 +15,6 @@ public class MavenParameters {
 	private final MavenProject mavenProject;
 	private final MojoExecution mojoExecution;
 	private final String versionRangeWithProjectVersion;
-
 	private final RepositorySystem repoSystem;
 	private final RepositorySystemSession repoSession;
 	private final List<RemoteRepository> remoteRepos;

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
@@ -1,7 +1,5 @@
 package japicmp.maven;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -13,37 +11,30 @@ import java.util.List;
 
 public class MavenParameters {
 	private final List<ArtifactRepository> artifactRepositories;
-	private final ArtifactFactory artifactFactory;
 	private final ArtifactRepository localRepository;
 	private final MavenProject mavenProject;
 	private final MojoExecution mojoExecution;
 	private final String versionRangeWithProjectVersion;
-	private final ArtifactMetadataSource metadataSource;
+
 	private final RepositorySystem repoSystem;
 	private final RepositorySystemSession repoSession;
 	private final List<RemoteRepository> remoteRepos;
-	
-	public MavenParameters(List<ArtifactRepository> artifactRepositories, ArtifactFactory artifactFactory, ArtifactRepository localRepository,
-						   MavenProject mavenProject, MojoExecution mojoExecution, String versionRangeWithProjectVersion, ArtifactMetadataSource metadataSource,
+
+	public MavenParameters(final List<ArtifactRepository> artifactRepositories, final ArtifactRepository localRepository,
+						   final MavenProject mavenProject, final MojoExecution mojoExecution, final String versionRangeWithProjectVersion,
 						   final RepositorySystem repoSystem, final RepositorySystemSession repoSession, final List<RemoteRepository> remoteRepos) {
 		this.artifactRepositories = artifactRepositories;
-		this.artifactFactory = artifactFactory;
 		this.localRepository = localRepository;
 		this.mavenProject = mavenProject;
 		this.mojoExecution = mojoExecution;
 		this.versionRangeWithProjectVersion = versionRangeWithProjectVersion;
-		this.metadataSource = metadataSource;
 		this.repoSystem = repoSystem;
 		this.repoSession = repoSession;
 		this.remoteRepos = remoteRepos;
 	}
-	
+
 	public List<ArtifactRepository> getArtifactRepositories() {
 		return artifactRepositories;
-	}
-
-	public ArtifactFactory getArtifactFactory() {
-		return artifactFactory;
 	}
 
 	public ArtifactRepository getLocalRepository() {
@@ -62,18 +53,14 @@ public class MavenParameters {
 		return versionRangeWithProjectVersion;
 	}
 
-	public ArtifactMetadataSource getMetadataSource() {
-		return metadataSource;
-	}
-	
 	public RepositorySystem getRepoSystem() {
 		return this.repoSystem;
 	}
-	
+
 	public RepositorySystemSession getRepoSession() {
 		return this.repoSession;
 	}
-	
+
 	public List<RemoteRepository> getRemoteRepos() {
 		return this.remoteRepos;
 	}

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
@@ -1,8 +1,6 @@
 package japicmp.maven;
 
 import japicmp.util.Optional;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.logging.Log;
@@ -93,8 +91,8 @@ public class SkipModuleStrategyTest {
 
 	private MavenParameters createMavenParameters() {
 		RemoteRepository remoteRepository = new RemoteRepository.Builder("id", "type", "http://example.org").build();
-		return new MavenParameters(new ArrayList<ArtifactRepository>(), mock(ArtifactFactory.class), mock(ArtifactRepository.class),
-			new MavenProject(), mock(MojoExecution.class), "", mock(ArtifactMetadataSource.class), mock(RepositorySystem.class), mock(
+		return new MavenParameters(new ArrayList<ArtifactRepository>(), mock(ArtifactRepository.class),
+			new MavenProject(), mock(MojoExecution.class), "", mock(RepositorySystem.class), mock(
 				RepositorySystemSession.class), Collections.singletonList(remoteRepository));
 	}
 


### PR DESCRIPTION
Dropped (unused) deprecated bits to get them out of plugin.
Also, reuse what Maven did for us already (resolved the project),
as Mojo requires compile resolution and that most probably
happened already in verify phase.

As "side effect" fixes https://github.com/siom79/japicmp/issues/327