### PR TITLE
Detect method varargs changes

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -265,6 +265,7 @@ public class CompatibilityChanges {
 				}
 			}
 			checkIfAnnotationDeprecatedAdded(constructor);
+			checkIfVarargsChanged(constructor);
 		}
 	}
 
@@ -367,6 +368,7 @@ public class CompatibilityChanges {
 			checkAbstractMethod(jApiClass, classMap, method);
 			checkIfExceptionIsNowChecked(method);
 			checkIfAnnotationDeprecatedAdded(method);
+			checkIfVarargsChanged(method);
 		}
 	}
 
@@ -377,6 +379,15 @@ public class CompatibilityChanges {
 					addCompatibilityChange((JApiCompatibility) jApiHasAnnotations, JApiCompatibilityChange.ANNOTATION_DEPRECATED_ADDED);
 				}
 			}
+		}
+	}
+
+	private void checkIfVarargsChanged(JApiBehavior behavior) {
+		if (behavior.getVarargsModifier().hasChangedFromTo(VarargsModifier.VARARGS, VarargsModifier.NON_VARARGS)) {
+			addCompatibilityChange(behavior, JApiCompatibilityChange.METHOD_NO_LONGER_VARARGS);
+		}
+		if (behavior.getVarargsModifier().hasChangedFromTo(VarargsModifier.NON_VARARGS, VarargsModifier.VARARGS)) {
+			addCompatibilityChange(behavior, JApiCompatibilityChange.METHOD_NOW_VARARGS);
 		}
 	}
 

--- a/japicmp/src/main/java/japicmp/model/JApiBehavior.java
+++ b/japicmp/src/main/java/japicmp/model/JApiBehavior.java
@@ -39,6 +39,7 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 	private final JApiModifier<BridgeModifier> bridgeModifier;
 	private final JApiModifier<SyntheticModifier> syntheticModifier;
 	private final JApiAttribute<SyntheticAttribute> syntheticAttribute;
+	private final JApiModifier<VarargsModifier> varargsModifier;
 	private final List<JApiException> exceptions;
 	protected JApiChangeStatus changeStatus;
 	private final Optional<Integer> oldLineNumber;
@@ -57,6 +58,7 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 		this.bridgeModifier = extractBridgeModifier(oldBehavior, newBehavior);
 		this.syntheticModifier = extractSyntheticModifier(oldBehavior, newBehavior);
 		this.syntheticAttribute = extractSyntheticAttribute(oldBehavior, newBehavior);
+		this.varargsModifier = extractVarargsModifier(oldBehavior, newBehavior);
 		this.exceptions = computeExceptionChanges(oldBehavior, newBehavior);
 		this.changeStatus = evaluateChangeStatus(changeStatus);
 		this.oldLineNumber = getLineNumber(oldBehavior);
@@ -179,6 +181,9 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 				changeStatus = JApiChangeStatus.MODIFIED;
 			}
 			if (this.syntheticAttribute.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
+				changeStatus = JApiChangeStatus.MODIFIED;
+			}
+			if (this.varargsModifier.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
 				changeStatus = JApiChangeStatus.MODIFIED;
 			}
 			for (JApiException jApiException : exceptions) {
@@ -330,6 +335,25 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 		});
 	}
 
+	private JApiModifier<VarargsModifier> extractVarargsModifier(Optional<? extends CtBehavior> oldBehaviorOptional, Optional<? extends CtBehavior> newBehaviorOptional) {
+		return ModifierHelper.extractModifierFromBehavior(oldBehaviorOptional, newBehaviorOptional, new ModifierHelper.ExtractModifierFromBehaviorCallback<VarargsModifier>() {
+			private VarargsModifier getModifier(CtBehavior behavior) {
+				return Modifier.isVarArgs(behavior.getModifiers()) ? VarargsModifier.VARARGS : VarargsModifier.NON_VARARGS;
+			}
+
+			@Override
+			public VarargsModifier getModifierForOld(CtBehavior oldBehavior) {
+				return getModifier(oldBehavior);
+			}
+
+			@Override
+			public VarargsModifier getModifierForNew(CtBehavior newBehavior) {
+				return getModifier(newBehavior);
+			}
+		});
+	}
+
+	@Override
 	@XmlElementWrapper(name = "modifiers")
 	@XmlElement(name = "modifier")
 	public List<? extends JApiModifier<? extends Enum<? extends Enum<?>>>> getModifiers() {
@@ -342,6 +366,7 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 	}
 
 	@XmlAttribute
+	@Override
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;
 	}
@@ -357,20 +382,24 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 	}
 
 	@XmlTransient
+	@Override
 	public JApiModifier<AccessModifier> getAccessModifier() {
 		return accessModifier;
 	}
 
 	@XmlTransient
+	@Override
 	public JApiModifier<FinalModifier> getFinalModifier() {
 		return finalModifier;
 	}
 
 	@XmlTransient
+	@Override
 	public JApiModifier<StaticModifier> getStaticModifier() {
 		return staticModifier;
 	}
 
+	@Override
 	public JApiModifier<AbstractModifier> getAbstractModifier() {
 		return this.abstractModifier;
 	}
@@ -384,18 +413,26 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 	}
 
 	@XmlTransient
+	@Override
 	public JApiModifier<BridgeModifier> getBridgeModifier() {
 		return this.bridgeModifier;
 	}
 
 	@XmlTransient
+	@Override
 	public JApiModifier<SyntheticModifier> getSyntheticModifier() {
 		return this.syntheticModifier;
 	}
 
 	@XmlTransient
+	@Override
 	public JApiAttribute<SyntheticAttribute> getSyntheticAttribute() {
 		return syntheticAttribute;
+	}
+
+	@XmlTransient
+	public JApiModifier<VarargsModifier> getVarargsModifier() {
+		return varargsModifier;
 	}
 
 	@Override
@@ -424,12 +461,14 @@ public class JApiBehavior implements JApiHasModifiers, JApiHasChangeStatus, JApi
 
 	@XmlElementWrapper(name = "compatibilityChanges")
 	@XmlElement(name = "compatibilityChange")
+	@Override
 	public List<JApiCompatibilityChange> getCompatibilityChanges() {
 		return compatibilityChanges;
 	}
 
 	@XmlElementWrapper(name = "annotations")
 	@XmlElement(name = "annotation")
+	@Override
 	public List<JApiAnnotation> getAnnotations() {
 		return annotations;
 	}

--- a/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
+++ b/japicmp/src/main/java/japicmp/model/JApiCompatibilityChange.java
@@ -28,6 +28,8 @@ public enum JApiCompatibilityChange {
 	METHOD_NOW_FINAL(false, false, JApiSemanticVersionLevel.MAJOR),
 	METHOD_NOW_STATIC(false, false, JApiSemanticVersionLevel.MAJOR),
 	METHOD_NO_LONGER_STATIC(false, false, JApiSemanticVersionLevel.MAJOR),
+	METHOD_NOW_VARARGS(true, true, JApiSemanticVersionLevel.MINOR),
+	METHOD_NO_LONGER_VARARGS(true, false, JApiSemanticVersionLevel.MINOR),
 	METHOD_ADDED_TO_INTERFACE(true, false, JApiSemanticVersionLevel.MINOR),
 	METHOD_ADDED_TO_PUBLIC_CLASS(true, true, JApiSemanticVersionLevel.PATCH),
 	METHOD_NOW_THROWS_CHECKED_EXCEPTION(true, false, JApiSemanticVersionLevel.MINOR),

--- a/japicmp/src/main/java/japicmp/model/VarargsModifier.java
+++ b/japicmp/src/main/java/japicmp/model/VarargsModifier.java
@@ -1,0 +1,8 @@
+package japicmp.model;
+
+/**
+ * Represents the varargs modifier of a callable.
+ */
+public enum VarargsModifier implements JApiModifierBase {
+	VARARGS, NON_VARARGS
+}

--- a/japicmp/src/main/java/japicmp/util/ModifierHelper.java
+++ b/japicmp/src/main/java/japicmp/util/ModifierHelper.java
@@ -1,6 +1,5 @@
 package japicmp.util;
 
-import japicmp.util.Optional;
 import japicmp.cmp.JarArchiveComparatorOptions;
 import japicmp.config.Options;
 import japicmp.model.AccessModifier;

--- a/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
+++ b/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
@@ -6,6 +6,8 @@ import japicmp.model.*;
 import japicmp.util.*;
 import javassist.ClassPool;
 import javassist.CtClass;
+import javassist.Modifier;
+
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
@@ -18,6 +20,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
 
 public class CompatibilityChangesTest {
 
@@ -644,6 +647,66 @@ public class CompatibilityChangesTest {
 		JApiMethod jApiMethod = getJApiMethod(jApiClass.getMethods(), "methodNoLongerStatic");
 		assertThat(jApiMethod.getCompatibilityChanges(), hasItem(JApiCompatibilityChange.METHOD_NO_LONGER_STATIC));
 		assertThat(jApiMethod.isBinaryCompatible(), is(false));
+	}
+
+	@Test
+	public void testMethodNowVarargs() throws Exception {
+		JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(options, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass arrayClass = classPool.getCtClass("[I");
+
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().parameter(arrayClass).name("methodNowVarargs").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass arrayClass = classPool.getCtClass("[I");
+
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().modifier(Modifier.VARARGS).publicAccess().parameter(arrayClass).name("methodNowVarargs").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "japicmp.Test");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+		JApiMethod jApiMethod = getJApiMethod(jApiClass.getMethods(), "methodNowVarargs");
+		assertEquals(jApiMethod.getCompatibilityChanges(), Collections.singletonList(JApiCompatibilityChange.METHOD_NOW_VARARGS));
+	}
+
+	@Test
+	public void testMethodNoLongerVarargs() throws Exception {
+		JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(options, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass arrayClass = classPool.getCtClass("[I");
+
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().modifier(Modifier.VARARGS).publicAccess().parameter(arrayClass).name("methodNoLongerVarargs").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass arrayClass = classPool.getCtClass("[I");
+
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.Test").addToClassPool(classPool);
+				CtMethodBuilder.create().publicAccess().parameter(arrayClass).name("methodNoLongerVarargs").addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "japicmp.Test");
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		JApiMethod jApiMethod = getJApiMethod(jApiClass.getMethods(), "methodNoLongerVarargs");
+		assertEquals(jApiMethod.getCompatibilityChanges(), Collections.singletonList(JApiCompatibilityChange.METHOD_NO_LONGER_VARARGS));
 	}
 
 	@Test

--- a/src/site/markdown/MavenPlugin.md
+++ b/src/site/markdown/MavenPlugin.md
@@ -281,6 +281,8 @@ for each check. This allows you to customize the following verifications:
 | METHOD_NOW_FINAL | false | false | MAJOR |
 | METHOD_NOW_STATIC | false | false | MAJOR |
 | METHOD_NO_LONGER_STATIC | false | false | MAJOR |
+| METHOD_NOW_VARARGS | true | true | MINOR |
+| METHOD_NO_LONGER_VARARGS | true | false | MINOR |
 | METHOD_ADDED_TO_INTERFACE | true | false | MINOR |
 | METHOD_ADDED_TO_PUBLIC_CLASS | true | true | PATCH |
 | METHOD_NOW_THROWS_CHECKED_EXCEPTION | true | false | MINOR |


### PR DESCRIPTION
Changing a method from varargs to non-varargs is most likely a source incompatible change:
```java
void test(int... args) {
}
// to:
void test(int[] args) {
}
```
Fails with the following source code:
```java
test(1, 2);
```

Changing a method from non-varargs to varargs is most likely source compatible (unless I am overlooking some corner case with overloads).

Feedback is appreciated!