### PR TITLE
Check constructors for changed checked exceptions

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -264,6 +264,7 @@ public class CompatibilityChanges {
 					addCompatibilityChange(constructor, JApiCompatibilityChange.CONSTRUCTOR_LESS_ACCESSIBLE);
 				}
 			}
+			checkIfExceptionIsNowChecked(constructor);
 			checkIfAnnotationDeprecatedAdded(constructor);
 		}
 	}
@@ -488,13 +489,13 @@ public class CompatibilityChanges {
 		return isAbstract;
 	}
 
-	private void checkIfExceptionIsNowChecked(JApiMethod method) {
-		for (JApiException exception : method.getExceptions()) {
-			if (exception.getChangeStatus() == JApiChangeStatus.NEW && exception.isCheckedException() && method.getChangeStatus() != JApiChangeStatus.NEW) {
-				addCompatibilityChange(method, JApiCompatibilityChange.METHOD_NOW_THROWS_CHECKED_EXCEPTION);
+	private void checkIfExceptionIsNowChecked(JApiBehavior behavior) {
+		for (JApiException exception : behavior.getExceptions()) {
+			if (exception.getChangeStatus() == JApiChangeStatus.NEW && exception.isCheckedException() && behavior.getChangeStatus() != JApiChangeStatus.NEW) {
+				addCompatibilityChange(behavior, JApiCompatibilityChange.METHOD_NOW_THROWS_CHECKED_EXCEPTION);
 			}
-			if (exception.getChangeStatus() == JApiChangeStatus.REMOVED && exception.isCheckedException() && method.getChangeStatus() != JApiChangeStatus.REMOVED) {
-				addCompatibilityChange(method, JApiCompatibilityChange.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION);
+			if (exception.getChangeStatus() == JApiChangeStatus.REMOVED && exception.isCheckedException() && behavior.getChangeStatus() != JApiChangeStatus.REMOVED) {
+				addCompatibilityChange(behavior, JApiCompatibilityChange.METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #110

This now uses `METHOD_NOW_THROWS_CHECKED_EXCEPTION` and `METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION` for constructors as well. Is that acceptable or do they have to be renamed?