### PR TITLE
Eagerly filter classes

### DIFF
--- a/japicmp/src/main/java/japicmp/cmp/ReducibleClassPool.java
+++ b/japicmp/src/main/java/japicmp/cmp/ReducibleClassPool.java
@@ -1,0 +1,14 @@
+package japicmp.cmp;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+
+/**
+ * A {@link ClassPool} that allows to remove a class from the pool.
+ */
+public class ReducibleClassPool extends ClassPool {
+  public void remove(CtClass ctClass) {
+	removeCached(ctClass.getName());
+  }
+}
+

--- a/japicmp/src/test/java/japicmp/cmp/ClassesHelper.java
+++ b/japicmp/src/test/java/japicmp/cmp/ClassesHelper.java
@@ -16,10 +16,12 @@ public class ClassesHelper {
 
 	public static List<JApiClass> compareClasses(JarArchiveComparatorOptions options, ClassesGenerator classesGenerator) throws Exception {
 		JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(options);
-		ClassPool classPool = jarArchiveComparator.getCommonClassPool();
-		List<CtClass> oldClasses = classesGenerator.createOldClasses(classPool);
+		ReducibleClassPool classPool = jarArchiveComparator.getCommonClassPool();
+		final List<CtClass> oldClasses = classesGenerator.createOldClasses(classPool);
 		List<CtClass> newClasses = classesGenerator.createNewClasses(classPool);
-		return jarArchiveComparator.compareClassLists(options, oldClasses, newClasses);
+		List<CtClass> filteredOldClasses = jarArchiveComparator.createListOfCtClasses(() -> oldClasses, classPool);
+		List<CtClass> filteredNewClasses = jarArchiveComparator.createListOfCtClasses(() -> newClasses, classPool);
+		return jarArchiveComparator.compareClassLists(options, filteredOldClasses, filteredNewClasses);
 	}
 
 	public static class CompareClassesResult {


### PR DESCRIPTION
Addresses #318.

Reduce the maximum memory requirement of the `JarArchiveComparator` by having it apply filters while classes are being loaded and removing them from the `ClassPool` when filtered.

If a package filter is encountered we switch to a 2 step procedure, first reading all package filters, then reloading all classes. (Quite annoying but I don't see an alternative apart from rejecting the PR).

Diff is a bit larger than desired so tests like `FilterTest`, that relied on filtering to happen after a `CtClass` is created, continue to work as-is.