### PR TITLE
Upgrade maven-core to fix vulnerability

### DIFF
--- a/japicmp-maven-plugin/pom.xml
+++ b/japicmp-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
 	</licenses>
 
 	<properties>
-		<mavenVersion>3.6.3</mavenVersion> <!-- maven.version property is reserved! -->
+		<mavenVersion>3.8.1</mavenVersion> <!-- maven.version property is reserved! -->
 		<resolver.version>1.4.1</resolver.version> <!-- keep in sync with maven version -->
 		<maven-plugin.version>3.6.4</maven-plugin.version>
 	</properties>


### PR DESCRIPTION
Hi, the current version of artifact org.apache.maven:maven-core:3.6.3 is subject to CVE: CVE-2021-26291 https://nvd.nist.gov/vuln/detail/CVE-2021-26291. Would you please consider upgrading it to the closest secure version 3.8.1 ?
The unit tests have been passed:
```[INFO] Scanning for projects...
[INFO] 
[INFO] -----------< com.github.siom79.japicmp:japicmp-maven-plugin >-----------
[INFO] Building japicmp-maven-plugin 0.16.1-SNAPSHOT
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ japicmp-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/lyuye/workspace/remediation/real_pr_repos/japicmp/japicmp-maven-plugin/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:compile (default-compile) @ japicmp-maven-plugin ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-plugin-plugin:3.6.4:descriptor (default-descriptor) @ japicmp-maven-plugin ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] bsh mojo extractor found 0 mojo descriptor.
[INFO] ant mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 2 mojo descriptors.
[INFO] 
[INFO] --- maven-plugin-plugin:3.6.4:helpmojo (help-descriptor) @ japicmp-maven-plugin ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] bsh mojo extractor found 0 mojo descriptor.
[INFO] ant mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 2 mojo descriptors.
[INFO] 
[INFO] --- maven-dependency-plugin:3.3.0:copy (copy) @ japicmp-maven-plugin ---
[INFO] Configured Artifact: com.google.guava:guava:19.0:jar
[INFO] Configured Artifact: com.google.guava:guava:18.0:jar
[INFO] Copying guava-19.0.jar to /Users/lyuye/workspace/remediation/real_pr_repos/japicmp/japicmp-maven-plugin/target/guava-19.0.jar
[INFO] Copying guava-18.0.jar to /Users/lyuye/workspace/remediation/real_pr_repos/japicmp/japicmp-maven-plugin/target/guava-18.0.jar
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ japicmp-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/lyuye/workspace/remediation/real_pr_repos/japicmp/japicmp-maven-plugin/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ japicmp-maven-plugin ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M7:test (default-test) @ japicmp-maven-plugin ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running japicmp.maven.SkipModuleStrategyTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.718 s - in japicmp.maven.SkipModuleStrategyTest
[INFO] Running japicmp.maven.JApiCmpMojoTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.211 s - in japicmp.maven.JApiCmpMojoTest
[INFO] Running japicmp.maven.VersionChangeTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in japicmp.maven.VersionChangeTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.539 s
[INFO] Finished at: 2022-08-31T13:40:49+08:00
[INFO] ------------------------------------------------------------------------```

Thank you for your attention!