### PR TITLE
Update/clean up plugins and dependencies

### DIFF
--- a/japicmp-ant-task/pom.xml
+++ b/japicmp-ant-task/pom.xml
@@ -24,7 +24,7 @@
 	</licenses>
 
 	<properties>
-		<ant.version>1.10.11</ant.version>
+		<ant.version>1.10.12</ant.version>
 	</properties>
 
 	<dependencies>
@@ -50,7 +50,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<excludes>
@@ -59,7 +58,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<configuration>
 					<includes>
@@ -80,9 +78,7 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -127,20 +123,21 @@
 					<overWriteSnapshots>true</overWriteSnapshots>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 
 	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.0.0</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/japicmp-maven-plugin/pom.xml
+++ b/japicmp-maven-plugin/pom.xml
@@ -24,33 +24,27 @@
 		</license>
 	</licenses>
 
-	<properties>
-		<mavenVersion>3.6.3</mavenVersion> <!-- maven.version property is reserved! -->
-		<resolver.version>1.4.1</resolver.version> <!-- keep in sync with maven version -->
-		<maven-plugin.version>3.6.4</maven-plugin.version>
-	</properties>
-
 	<prerequisites>
-		<maven>${mavenVersion}</maven>
+		<maven>${maven-api.version}</maven>
 	</prerequisites>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>${mavenVersion}</version>
+			<version>${maven-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${mavenVersion}</version>
+			<version>${maven-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>${mavenVersion}</version>
+			<version>${maven-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -62,7 +56,7 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>${maven-plugin.version}</version>
+			<version>${plugin-annotation.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -71,12 +65,12 @@
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-api</artifactId>
-			<version>3.1.0</version>
+			<version>${reporting.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-impl</artifactId>
-			<version>3.1.0</version>
+			<version>${reporting.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
@@ -105,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>${maven-plugin.version}</version>
+				<version>${plugin-annotation.version}</version>
 				<executions>
 					<execution>
 						<id>default-descriptor</id>
@@ -124,9 +118,7 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -157,20 +149,21 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 
 	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.0.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/japicmp-testbase/japicmp-test-ant-task/pom.xml
+++ b/japicmp-testbase/japicmp-test-ant-task/pom.xml
@@ -20,9 +20,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -76,7 +74,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>test </phase>

--- a/japicmp-testbase/japicmp-test-maven-plugin-bundle-v1/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-bundle-v1/pom.xml
@@ -15,7 +15,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.2</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/japicmp-testbase/japicmp-test-maven-plugin-bundle-v2/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-bundle-v2/pom.xml
@@ -15,7 +15,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.2</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/japicmp-testbase/japicmp-test-maven-plugin-classifier/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-classifier/pom.xml
@@ -64,7 +64,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-maven-plugin-packaging/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-packaging/pom.xml
@@ -50,7 +50,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-maven-plugin-pom-module/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-pom-module/pom.xml
@@ -47,7 +47,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-maven-plugin-post-analysis-script-artifact-test/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-post-analysis-script-artifact-test/pom.xml
@@ -60,7 +60,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-maven-plugin-userproperty/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin-userproperty/pom.xml
@@ -53,7 +53,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -43,9 +43,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy</id>

--- a/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/pom.xml
+++ b/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/pom.xml
@@ -26,9 +26,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -124,7 +122,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<executions>
 					<execution>

--- a/japicmp-testbase/japicmp-test-v2/pom.xml
+++ b/japicmp-testbase/japicmp-test-v2/pom.xml
@@ -112,7 +112,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
@@ -173,9 +172,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.0.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/japicmp-testbase/japicmp-test-vx-client/pom.xml
+++ b/japicmp-testbase/japicmp-test-vx-client/pom.xml
@@ -30,7 +30,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
@@ -44,9 +43,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -80,7 +77,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.6.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>withOldVersion</id>

--- a/japicmp-testbase/japicmp-test/pom.xml
+++ b/japicmp-testbase/japicmp-test/pom.xml
@@ -36,9 +36,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy</id>
@@ -89,7 +87,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
 						<skip>true</skip>

--- a/japicmp-testbase/pom.xml
+++ b/japicmp-testbase/pom.xml
@@ -51,7 +51,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -33,23 +33,16 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
-			<version>1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>2.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>2.3.2</version>
 		</dependency>
 	</dependencies>
 
@@ -57,7 +50,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.0.0</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -85,20 +77,21 @@
 					<show>private</show>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 
 	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.0.0</version>
 			</plugin>
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
@@ -126,7 +119,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pom.xml
+++ b/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.siom79.japicmp</groupId>
-    <artifactId>japicmp-base</artifactId>
-    <version>0.16.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
+	<groupId>com.github.siom79.japicmp</groupId>
+	<artifactId>japicmp-base</artifactId>
+	<version>0.16.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-    <name>japicmp-base</name>
-    <description>japicmp is a tool/maven plugin that compares two versions of a jar archive for binary compatibility.</description>
-    <url>https://github.com/siom79/japicmp</url>
+	<name>japicmp-base</name>
+	<description>japicmp is a tool/maven plugin that compares two versions of a jar archive for binary compatibility.</description>
+	<url>https://github.com/siom79/japicmp</url>
 
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-    <developers>
-        <developer>
-            <id>martin.mois</id>
-            <name>Martin Mois</name>
-            <email>martin.mois@gmail.com</email>
-        </developer>
-    </developers>
+	<developers>
+		<developer>
+			<id>martin.mois</id>
+			<name>Martin Mois</name>
+			<email>martin.mois@gmail.com</email>
+		</developer>
+	</developers>
 	<contributors>
 		<contributor>
 			<name>Loki</name>
@@ -130,49 +130,53 @@
 		</contributor>
 	</contributors>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <github.account>siom79</github.account>
-        <github.project>japicmp</github.project>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<github.account>siom79</github.account>
+		<github.project>japicmp</github.project>
 		<maven.site.skip>false</maven.site.skip>
+		<maven-api.version>3.6.3</maven-api.version>
+		<resolver.version>1.4.1</resolver.version> <!-- keep in sync with maven api version -->
+		<reporting.version>3.1.0</reporting.version>
+		<plugin-annotation.version>3.6.4</plugin-annotation.version>
 		<surefireVersion>3.0.0-M7</surefireVersion>
 		<javassist.version>3.24.0-GA</javassist.version>
 		<guava.version>30.1-jre</guava.version>
-		<jaxb.version>2.2.7</jaxb.version>
+		<jaxb.version>2.3.2</jaxb.version>
 		<javax-activation.version>1.1</javax-activation.version>
 		<sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots</sonatypeOssDistMgmtSnapshotsUrl>
-    </properties>
+	</properties>
 
-    <modules>
-        <module>japicmp</module>
-        <module>japicmp-testbase</module>
-        <module>japicmp-maven-plugin</module>
+	<modules>
+		<module>japicmp</module>
+		<module>japicmp-testbase</module>
+		<module>japicmp-maven-plugin</module>
 		<module>japicmp-ant-task</module>
 	</modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.12.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>1.12.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>4.3.1</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 	<dependencyManagement>
 		<dependencies>
@@ -187,18 +191,13 @@
 				<version>${guava.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.xml.bind</groupId>
-				<artifactId>jaxb-api</artifactId>
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
 				<version>${jaxb.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.sun.xml.bind</groupId>
-				<artifactId>jaxb-core</artifactId>
-				<version>${jaxb.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.sun.xml.bind</groupId>
-				<artifactId>jaxb-impl</artifactId>
+				<groupId>org.glassfish.jaxb</groupId>
+				<artifactId>jaxb-runtime</artifactId>
 				<version>${jaxb.version}</version>
 			</dependency>
 			<dependency>
@@ -209,7 +208,7 @@
 		</dependencies>
 	</dependencyManagement>
 
-    <build>
+	<build>
 		<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
@@ -218,16 +217,36 @@
 			</extension>
 		</extensions>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-        </plugins>
+		<plugins>
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>${maven-api.version}</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>${maven.compiler.target}</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 
 		<pluginManagement>
 			<plugins>
@@ -252,7 +271,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.4.1</version>
 					<configuration>
 						<quiet>true</quiet>
 					</configuration>
@@ -282,7 +301,7 @@
 					<!-- explicitly define maven-deploy-plugin after other to force exec order -->
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.0.0-M2</version>
+					<version>3.0.0</version>
 					<executions>
 						<execution>
 							<id>deploy</id>
@@ -306,12 +325,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.3.0</version>
+					<version>3.4.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.2.2</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -331,11 +350,31 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.6</version>
+					<version>5.1.8</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-checkstyle-plugin</artifactId>
+					<version>3.2.0</version>
+				</plugin>
+				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
+					<version>4.7.2.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>3.4.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
-    </build>
+	</build>
 
 	<scm>
 		<connection>scm:git:https://github.com/${github.account}/${github.project}.git</connection>
@@ -361,24 +400,24 @@
 		</repository>
 	</distributionManagement>
 
-    <profiles>
-        <profile>
-           <id>doclint-java8-disabled</id>
-           <activation>
-              <jdk>[1.8,)</jdk>
-           </activation>
-           <build>
-              <plugins>
-                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-					 <configuration>
-						 <source>8</source>
-					 </configuration>
-                 </plugin>
-              </plugins>
-           </build>
-        </profile>
+	<profiles>
+		<profile>
+			<id>doclint-java8-disabled</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<source>8</source>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>java-9</id>
 			<activation>
@@ -505,7 +544,7 @@
 				</plugins>
 			</build>
 		</profile>
-    </profiles>
+	</profiles>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
- move version declarations and/or properties to parent pom;
- update plugin versions;
- remove superfluous group ids;
- replace findbugs with actively developed drop-in spotbugs;
- remove unused old JAXB dependency;
- add enforcer plugin.