### PR TITLE
Check implemented interfaces for default methods of super interface

### DIFF
--- a/japicmp-testbase/japicmp-test-v1/src/main/java/japicmp/test/DefaultMethod.java
+++ b/japicmp-testbase/japicmp-test-v1/src/main/java/japicmp/test/DefaultMethod.java
@@ -17,4 +17,41 @@ public class DefaultMethod {
     public abstract class CAbstract implements IAbstract {
     
     }
+
+	public static class DefaultInSubInterface {
+		public interface IInterface {}
+
+		public interface IInterfaceWithDefault extends IInterface {}
+
+		public static abstract class CClass implements IInterfaceWithDefault {}
+	}
+
+	public static class UnrelatedDefaultInSubInterface {
+		public interface IInterface {}
+
+		public interface IInterfaceWithDefault extends IInterface {}
+
+		public static abstract class CClass implements IInterfaceWithDefault {}
+	}
+
+	public static class DefaultInParentInterface {
+		public interface IInterfaceWithDefault {}
+
+		public interface IInterface extends IInterfaceWithDefault {}
+
+		public static abstract class CClass implements IInterface {}
+	}
+
+	public static class DefaultInSubInterfaceAddedSuperclass {
+		public interface IInterface {
+			void foo();
+		}
+
+		public interface IInterfaceWithDefault extends IInterface {
+			@Override
+			default void foo() {}
+		}
+
+		public static abstract class CClass implements IInterfaceWithDefault {}
+	}
 }

--- a/japicmp-testbase/japicmp-test-v2/src/main/java/japicmp/test/DefaultMethod.java
+++ b/japicmp-testbase/japicmp-test-v2/src/main/java/japicmp/test/DefaultMethod.java
@@ -19,4 +19,57 @@ public class DefaultMethod {
     public abstract class CAbstract implements IAbstract {
     
     }
+
+	public static class DefaultInSubInterface {
+		public interface IInterface {
+			void foo();
+		}
+
+		public interface IInterfaceWithDefault extends IInterface {
+			@Override
+			default void foo() {}
+		}
+
+		public abstract static class CClass implements IInterfaceWithDefault {}
+	}
+
+	public static class UnrelatedDefaultInSubInterface {
+		public interface IInterface {
+			void foo();
+		}
+
+		public interface IInterfaceWithDefault extends IInterface {
+			default void bar() {}
+		}
+
+		public static abstract class CClass implements IInterfaceWithDefault {}
+	}
+
+	public static class DefaultInParentInterface {
+		public interface IInterfaceWithDefault {
+			default void foo() {}
+		}
+
+		public interface IInterface extends IInterfaceWithDefault {
+			@Override
+			void foo();
+		}
+
+		public abstract static class CClass implements IInterface {}
+	}
+
+	public static class DefaultInSubInterfaceAddedSuperclass {
+		public interface IInterface {
+			void foo();
+		}
+
+		public interface IInterfaceWithDefault extends IInterface {
+			@Override
+			default void foo() {}
+		}
+
+		public static class CAddedSuperClass implements IInterfaceWithDefault {}
+
+		public abstract static class CClass extends CAddedSuperClass {}
+	}
 }

--- a/japicmp-testbase/japicmp-test/pom.xml
+++ b/japicmp-testbase/japicmp-test/pom.xml
@@ -31,6 +31,12 @@
 			<artifactId>japicmp-test2-v2</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/DefaultMethodTest.java
+++ b/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/DefaultMethodTest.java
@@ -15,6 +15,7 @@ import static japicmp.test.util.Helper.getArchive;
 import static japicmp.test.util.Helper.getJApiClass;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 public class DefaultMethodTest {
@@ -43,4 +44,54 @@ public class DefaultMethodTest {
         assertThat(jApiClass.isSourceCompatible(), is(false));
         MatcherAssert.assertThat(jApiClass.getCompatibilityChanges(), hasItem(JApiCompatibilityChange.METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE));
     }
+
+	@Test
+	public void testCompatibilityAddMethodAndDefaultInSubInterfaces() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, DefaultMethod.DefaultInSubInterface.CClass.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		MatcherAssert.assertThat(
+				jApiClass.getCompatibilityChanges(),
+				containsInAnyOrder(
+						JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+	}
+
+	@Test
+	public void testCompatibilityAddMethodAndDefaultInSubInterfacesChecksForExactMatch() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, DefaultMethod.UnrelatedDefaultInSubInterface.CClass.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		MatcherAssert.assertThat(
+				jApiClass.getCompatibilityChanges(),
+				containsInAnyOrder(
+						JApiCompatibilityChange.METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE,
+						JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+	}
+
+	@Test
+	public void testCompatibilityAddMethodWithDefaultAndOverrideInSubInterfaces() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, DefaultMethod.DefaultInParentInterface.CClass.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.UNCHANGED));
+		MatcherAssert.assertThat(
+				jApiClass.getCompatibilityChanges(),
+				containsInAnyOrder(
+						JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE,
+						JApiCompatibilityChange.METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+	}
+
+	@Test
+	public void testCompatibilityAddSuperClass() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, DefaultMethod.DefaultInSubInterfaceAddedSuperclass.CClass.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		MatcherAssert.assertThat(
+				jApiClass.getCompatibilityChanges(),
+				containsInAnyOrder(
+						JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE));
+		assertThat(jApiClass.isBinaryCompatible(), is(true));
+		assertThat(jApiClass.isSourceCompatible(), is(true));
+	}
 }

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -909,6 +909,28 @@ public class CompatibilityChanges {
 					}
 				}
 			}
+			final List<JApiMethod> abstractMethodsWithDefaultInInterface = new ArrayList<>();
+			for (JApiMethod abstractMethod : abstractMethods) {
+				for (JApiImplementedInterface implementedInterface : implementedInterfaces) {
+					final JApiClass interfaceClass = getJApiClass(implementedInterface, classMap);
+					for (JApiMethod defaultMethodCandidate : interfaceClass.getMethods()) {
+						if (!isAbstract(defaultMethodCandidate)
+								&& areMatching(abstractMethod, defaultMethodCandidate)) {
+							// we have a default implementation for this method
+							// double-check that we extend interface that the method comes from
+							for (JApiImplementedInterface extendedInterface : interfaceClass.getInterfaces()) {
+								JApiClass extendedInterfaceClass = getJApiClass(extendedInterface, classMap);
+
+								if (abstractMethod.getjApiClass().equals(extendedInterfaceClass)) {
+									abstractMethodsWithDefaultInInterface.add(abstractMethod);
+								}
+							}
+						}
+					}
+				}
+			}
+			abstractMethods.removeAll(abstractMethodsWithDefaultInInterface);
+
 			if (!abstractMethods.isEmpty()) {
 				addCompatibilityChange(jApiClass, JApiCompatibilityChange.METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE);
 			}

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -890,7 +890,7 @@ public class CompatibilityChanges {
 				for (JApiMethod interfaceMethod : interfaceClass.getMethods()) {
 					boolean isImplemented = false;
 					for (JApiMethod implementedMethod : implementedMethods) {
-						if (interfaceMethod.getName().equals(implementedMethod.getName()) && interfaceMethod.hasSameSignature(implementedMethod)) {
+						if (areMatching(interfaceMethod, implementedMethod)) {
 							isImplemented = true;
 							break;
 						}
@@ -916,6 +916,11 @@ public class CompatibilityChanges {
 				addCompatibilityChange(jApiClass, JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE);
 			}
 		}
+	}
+
+	private static boolean areMatching(JApiMethod left, JApiMethod right) {
+		return left.getName().equals(right.getName())
+				&& left.hasSameSignature(right);
 	}
 
 	private JApiClass getJApiClass(JApiImplementedInterface implementedInterface, Map<String, JApiClass> classMap) {

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -886,11 +886,7 @@ public class CompatibilityChanges {
 			}
 			abstractMethods.clear();
 			for (JApiImplementedInterface jApiImplementedInterface : implementedInterfaces) {
-				String fullyQualifiedName = jApiImplementedInterface.getFullyQualifiedName();
-				JApiClass interfaceClass = classMap.get(fullyQualifiedName);
-				if (interfaceClass == null) {
-					interfaceClass = loadClass(fullyQualifiedName, EnumSet.allOf(Classpath.class));
-				}
+				JApiClass interfaceClass = getJApiClass(jApiImplementedInterface, classMap);
 				for (JApiMethod interfaceMethod : interfaceClass.getMethods()) {
 					boolean isImplemented = false;
 					for (JApiMethod implementedMethod : implementedMethods) {
@@ -920,6 +916,15 @@ public class CompatibilityChanges {
 				addCompatibilityChange(jApiClass, JApiCompatibilityChange.METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE);
 			}
 		}
+	}
+
+	private JApiClass getJApiClass(JApiImplementedInterface implementedInterface, Map<String, JApiClass> classMap) {
+		String fullyQualifiedName = implementedInterface.getFullyQualifiedName();
+		JApiClass interfaceClass = classMap.get(fullyQualifiedName);
+		if (interfaceClass == null) {
+			interfaceClass = loadClass(fullyQualifiedName, EnumSet.allOf(Classpath.class));
+		}
+		return interfaceClass;
 	}
 
 	private void checkIfClassNowCheckedException(JApiClass jApiClass) {


### PR DESCRIPTION
Resolves an issue default methods weren't considered when the method was first declared in another interface higher up in the hierarchy.
We now double-check for all discovered abstract methods whether an implemented interface has a default method for that method. We only accept such a default method if the interface containing it extends the interface with the original definition.