### PR TITLE
Detect methods moved to super class with added final

### DIFF
--- a/japicmp-testbase/japicmp-test-v1/src/main/java/japicmp/test/semver/finalpublicmethod/ClassWithFinalPublicMethodInSuperClass.java
+++ b/japicmp-testbase/japicmp-test-v1/src/main/java/japicmp/test/semver/finalpublicmethod/ClassWithFinalPublicMethodInSuperClass.java
@@ -1,0 +1,10 @@
+package japicmp.test.semver.finalpublicmethod;
+
+public class ClassWithFinalPublicMethodInSuperClass {
+
+	public static class SuperClass {}
+
+	public static class SubClass extends SuperClass {
+		public void foo() {}
+	}
+}

--- a/japicmp-testbase/japicmp-test-v2/src/main/java/japicmp/test/semver/finalpublicmethod/ClassWithFinalPublicMethodInSuperClass.java
+++ b/japicmp-testbase/japicmp-test-v2/src/main/java/japicmp/test/semver/finalpublicmethod/ClassWithFinalPublicMethodInSuperClass.java
@@ -1,0 +1,10 @@
+package japicmp.test.semver.finalpublicmethod;
+
+public class ClassWithFinalPublicMethodInSuperClass {
+
+	public static class SuperClass {
+		public final void foo() {}
+	}
+
+	public static class SubClass extends SuperClass {	}
+}

--- a/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/FinalMethodTest.java
+++ b/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/FinalMethodTest.java
@@ -1,0 +1,59 @@
+package japicmp.test;
+
+import japicmp.cmp.JarArchiveComparator;
+import japicmp.cmp.JarArchiveComparatorOptions;
+import japicmp.compat.CompatibilityChanges;
+import japicmp.model.JApiChangeStatus;
+import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibilityChange;
+import japicmp.test.semver.finalpublicmethod.ClassWithFinalPublicMethod;
+import japicmp.test.semver.finalpublicmethod.ClassWithFinalPublicMethodInSuperClass;
+import org.hamcrest.MatcherAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static japicmp.test.util.Helper.getArchive;
+import static japicmp.test.util.Helper.getJApiClass;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+public class FinalMethodTest {
+	private static List<JApiClass> jApiClasses;
+
+	@BeforeClass
+	public static void beforeClass() {
+		JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(new JarArchiveComparatorOptions());
+		jApiClasses = jarArchiveComparator.compare(getArchive("japicmp-test-v1.jar"), getArchive("japicmp-test-v2.jar"));
+	}
+
+	@Test
+	public void testCompatibilityAddFinalToMethod() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, ClassWithFinalPublicMethod.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		MatcherAssert.assertThat(
+				getMethodCompatibilityChanges(jApiClass),
+				containsInAnyOrder(JApiCompatibilityChange.METHOD_NOW_FINAL));
+	}
+
+	@Test
+	public void testCompatibilityAddFinalToMethodAndMoveToSuperclass() {
+		JApiClass jApiClass = getJApiClass(jApiClasses, ClassWithFinalPublicMethodInSuperClass.SubClass.class.getName());
+		assertThat(jApiClass.getChangeStatus(), is(JApiChangeStatus.MODIFIED));
+		assertThat(jApiClass.isBinaryCompatible(), is(false));
+		assertThat(jApiClass.isSourceCompatible(), is(false));
+		MatcherAssert.assertThat(
+				getMethodCompatibilityChanges(jApiClass),
+				containsInAnyOrder(JApiCompatibilityChange.METHOD_NOW_FINAL));
+	}
+
+	private static Collection<JApiCompatibilityChange> getMethodCompatibilityChanges(JApiClass jApiClass) {
+		return jApiClass.getMethods().stream().flatMap(method -> method.getCompatibilityChanges().stream()).collect(Collectors.toList());
+	}
+}

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -307,7 +307,7 @@ public class CompatibilityChanges {
 					@Override
 					public Integer callback(JApiClass superclass, Map<String, JApiClass> classMap, JApiChangeStatus changeStatusOfSuperclass) {
 						for (JApiMethod superMethod : superclass.getMethods()) {
-							if (superMethod.getName().equals(method.getName()) && superMethod.hasSameParameter(method) && superMethod.hasSameReturnType(method)) {
+							if (superMethod.getName().equals(method.getName()) && superMethod.hasSameSignature(method)) {
 								return 1;
 							}
 						}
@@ -341,7 +341,7 @@ public class CompatibilityChanges {
 					@Override
 					public Integer callback(JApiClass superclass, Map<String, JApiClass> classMap, JApiChangeStatus changeStatusOfSuperclass) {
 						for (JApiMethod superMethod : superclass.getMethods()) {
-							if (superMethod.getName().equals(method.getName()) && superMethod.hasSameParameter(method) && superMethod.hasSameReturnType(method)) {
+							if (superMethod.getName().equals(method.getName()) && superMethod.hasSameSignature(method)) {
 								if (superMethod.getAccessModifier().getNewModifier().isPresent() && method.getAccessModifier().getNewModifier().isPresent()) {
 									if (superMethod.getAccessModifier().getNewModifier().get().getLevel() > method.getAccessModifier().getNewModifier().get().getLevel()) {
 										return 1;
@@ -586,7 +586,7 @@ public class CompatibilityChanges {
 	private void checkIfMethodHasBeenPulledUp(JApiClass jApiClass, Map<String, JApiClass> classMap, final JApiMethod method, List<Integer> returnValues) {
 		forAllImplementedInterfaces(jApiClass, classMap, returnValues, new ArrayList<>(), (implementedInterface, classMap1) -> {
 			for (JApiMethod superMethod : implementedInterface.getMethods()) {
-				if (superMethod.getName().equals(method.getName()) && superMethod.hasSameParameter(method) && superMethod.hasSameReturnType(method)) {
+				if (superMethod.getName().equals(method.getName()) && superMethod.hasSameSignature(method)) {
 					return 1;
 				}
 			}

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -378,6 +378,26 @@ public class CompatibilityChanges {
 					addCompatibilityChange(method, JApiCompatibilityChange.METHOD_NOW_FINAL);
 				}
 			}
+			if (isNotPrivate(method) && method.getChangeStatus() == JApiChangeStatus.REMOVED) {
+				List<Integer> returnValues = new ArrayList<>();
+				forAllSuperclasses(jApiClass, classMap, returnValues, new OnSuperclassCallback<Integer>() {
+					@Override
+					public Integer callback(JApiClass superclass, Map<String, JApiClass> classMap, JApiChangeStatus changeStatusOfSuperclass) {
+						for (JApiMethod superMethod : superclass.getMethods()) {
+							if (areMatching(superMethod, method)) {
+								if (method.getFinalModifier().getOldModifier().get() == FinalModifier.NON_FINAL
+										&& superMethod.getFinalModifier().getNewModifier().get() == FinalModifier.FINAL) {
+									return 1;
+								}
+							}
+						}
+						return 0;
+					}
+				});
+				if (returnValues.stream().anyMatch(value -> value == 1)) {
+					addCompatibilityChange(method, JApiCompatibilityChange.METHOD_NOW_FINAL);
+				}
+			}
 			// section 13.4.18 of "Java Language Specification" SE7
 			if (isNotPrivate(method)) {
 				if (method.getStaticModifier().hasChangedFromTo(StaticModifier.NON_STATIC, StaticModifier.STATIC)) {


### PR DESCRIPTION
The plugin currently can detect when a method was moved to a sub class, but it doesn't take all properties into account, including (but not limited to) `final` and access modifiers.

With this PR it can detect if `final` was added when it moved to the super class.
