### PR TITLE
Remove javax.activation dependency

### DIFF
--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -33,10 +33,6 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,6 @@
 		<javassist.version>3.29.1-GA</javassist.version>
 		<guava.version>30.1-jre</guava.version>
 		<jaxb.version>2.3.2</jaxb.version>
-		<javax-activation.version>1.1</javax-activation.version>
 		<sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots</sonatypeOssDistMgmtSnapshotsUrl>
 	</properties>
 
@@ -193,11 +192,6 @@
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
 				<version>${jaxb.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.activation</groupId>
-				<artifactId>activation</artifactId>
-				<version>${javax-activation.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
As far as I can tell this is no longer required/used.