### PR TITLE
Drop unused parameter ${localRepository}.

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -90,8 +90,6 @@ public class JApiCmpMojo extends AbstractMojo {
 	private RepositorySystemSession repoSession;
 	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
 	private List<RemoteRepository> remoteRepos;
-	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "${localRepository}")
-	private ArtifactRepository localRepository;
 	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "${project.remoteArtifactRepositories}")
 	private List<ArtifactRepository> artifactRepositories;
 	@org.apache.maven.plugins.annotations.Parameter(defaultValue = "${project}")
@@ -103,7 +101,7 @@ public class JApiCmpMojo extends AbstractMojo {
 	private Options options;
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		MavenParameters mavenParameters = new MavenParameters(this.artifactRepositories, this.localRepository,
+		MavenParameters mavenParameters = new MavenParameters(this.artifactRepositories,
 			this.mavenProject, this.mojoExecution, this.versionRangeWithProjectVersion, this.repoSystem, this.repoSession,
 			this.remoteRepos);
 		PluginParameters pluginParameters = new PluginParameters(this.skip, this.newVersion, this.oldVersion, this.parameter, this.dependencies, Optional.of(
@@ -903,7 +901,6 @@ public class JApiCmpMojo extends AbstractMojo {
 	}
 
 	private Set<Artifact> resolveArtifact(Artifact artifact, MavenParameters mavenParameters, PluginParameters pluginParameters, ConfigurationVersion configurationVersion) throws MojoFailureException {
-		notNull(mavenParameters.getLocalRepository(), "Maven parameter localRepository should be provided by maven container.");
 		notNull(mavenParameters.getRepoSystem(), "Maven parameter repoSystem should be provided by maven container.");
 		notNull(mavenParameters.getRepoSession(), "Maven parameter repoSession should be provided by maven container.");
 		ArtifactRequest request = new ArtifactRequest();

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpReport.java
@@ -102,7 +102,7 @@ public class JApiCmpReport extends AbstractMavenReport {
 			return this.mojo;
 		}
 		this.mojo = new JApiCmpMojo();
-		this.mavenParameters = new MavenParameters(this.artifactRepositories, this.localRepository,
+		this.mavenParameters = new MavenParameters(this.artifactRepositories,
 				this.mavenProject, this.mojoExecution, this.versionRangeWithProjectVersion, this.repoSystem, this.repoSession,
 				this.remoteRepos);
 		this.pluginParameters = new PluginParameters(this.skip, this.newVersion, this.oldVersion, this.parameter, this.dependencies, Optional.<File>absent(), Optional.of(

--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/MavenParameters.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 public class MavenParameters {
 	private final List<ArtifactRepository> artifactRepositories;
-	private final ArtifactRepository localRepository;
 	private final MavenProject mavenProject;
 	private final MojoExecution mojoExecution;
 	private final String versionRangeWithProjectVersion;
@@ -19,11 +18,10 @@ public class MavenParameters {
 	private final RepositorySystemSession repoSession;
 	private final List<RemoteRepository> remoteRepos;
 
-	public MavenParameters(final List<ArtifactRepository> artifactRepositories, final ArtifactRepository localRepository,
+	public MavenParameters(final List<ArtifactRepository> artifactRepositories,
 						   final MavenProject mavenProject, final MojoExecution mojoExecution, final String versionRangeWithProjectVersion,
 						   final RepositorySystem repoSystem, final RepositorySystemSession repoSession, final List<RemoteRepository> remoteRepos) {
 		this.artifactRepositories = artifactRepositories;
-		this.localRepository = localRepository;
 		this.mavenProject = mavenProject;
 		this.mojoExecution = mojoExecution;
 		this.versionRangeWithProjectVersion = versionRangeWithProjectVersion;
@@ -34,10 +32,6 @@ public class MavenParameters {
 
 	public List<ArtifactRepository> getArtifactRepositories() {
 		return artifactRepositories;
-	}
-
-	public ArtifactRepository getLocalRepository() {
-		return localRepository;
 	}
 
 	public MavenProject getMavenProject() {

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/SkipModuleStrategyTest.java
@@ -91,7 +91,7 @@ public class SkipModuleStrategyTest {
 
 	private MavenParameters createMavenParameters() {
 		RemoteRepository remoteRepository = new RemoteRepository.Builder("id", "type", "http://example.org").build();
-		return new MavenParameters(new ArrayList<ArtifactRepository>(), mock(ArtifactRepository.class),
+		return new MavenParameters(new ArrayList<ArtifactRepository>(), 
 			new MavenProject(), mock(MojoExecution.class), "", mock(RepositorySystem.class), mock(
 				RepositorySystemSession.class), Collections.singletonList(remoteRepository));
 	}


### PR DESCRIPTION
Not only it is unused, but starting with Maven 3.9.1 it will cause a WARNING, making plugin look bad.

For details, see here:
https://issues.apache.org/jira/browse/MNG-7706