### PR TITLE
There are a LOT of warnings that plugin is missing version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>enforce-versions</id>


### PR DESCRIPTION
It is best practice to "lock down" plugin versions, as otherwise they may become "moving target".