### PR TITLE
Make classes implement `JApiHasChangeStatus` if they already do

### DIFF
--- a/japicmp/src/main/java/japicmp/model/JApiAttribute.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAttribute.java
@@ -6,7 +6,7 @@ import japicmp.util.OptionalHelper;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlTransient;
 
-public class JApiAttribute<T> {
+public class JApiAttribute<T> implements JApiHasChangeStatus {
 	private final Optional<T> oldAttribute;
 	private final Optional<T> newAttribute;
 	private final JApiChangeStatus changeStatus;
@@ -27,6 +27,7 @@ public class JApiAttribute<T> {
 		return newAttribute;
 	}
 
+	@Override
 	@XmlAttribute(name = "changeStatus")
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;

--- a/japicmp/src/main/java/japicmp/model/JApiClassType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClassType.java
@@ -6,7 +6,7 @@ import japicmp.util.OptionalHelper;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlTransient;
 
-public class JApiClassType {
+public class JApiClassType implements JApiHasChangeStatus {
 	private final Optional<ClassType> oldTypeOptional;
 	private final Optional<ClassType> newTypeOptional;
 	private final JApiChangeStatus changeStatus;
@@ -31,6 +31,7 @@ public class JApiClassType {
 		return OptionalHelper.optionalToString(newTypeOptional);
 	}
 
+	@Override
 	@XmlAttribute
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;

--- a/japicmp/src/main/java/japicmp/model/JApiModifier.java
+++ b/japicmp/src/main/java/japicmp/model/JApiModifier.java
@@ -5,7 +5,7 @@ import japicmp.util.OptionalHelper;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
-public class JApiModifier<T> {
+public class JApiModifier<T> implements JApiHasChangeStatus {
 	private final Optional<T> oldModifier;
 	private final Optional<T> newModifier;
 	private final JApiChangeStatus changeStatus;
@@ -24,6 +24,7 @@ public class JApiModifier<T> {
 		return newModifier;
 	}
 
+	@Override
 	@XmlAttribute(name = "changeStatus")
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;

--- a/japicmp/src/main/java/japicmp/model/JApiReturnType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiReturnType.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
 
-public class JApiReturnType implements JApiHasGenericTypes, JApiCompatibility {
+public class JApiReturnType implements JApiHasGenericTypes, JApiHasChangeStatus, JApiCompatibility {
 	private final Optional<String> oldReturnTypeOptional;
 	private final Optional<String> newReturnTypeOptional;
 	private final JApiChangeStatus changeStatus;
@@ -23,6 +23,7 @@ public class JApiReturnType implements JApiHasGenericTypes, JApiCompatibility {
 		this.newReturnTypeOptional = newReturnTypeOptional;
 	}
 
+	@Override
 	@XmlAttribute(name = "changeStatus")
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;

--- a/japicmp/src/main/java/japicmp/model/JApiType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiType.java
@@ -6,7 +6,7 @@ import japicmp.util.OptionalHelper;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlTransient;
 
-public class JApiType {
+public class JApiType implements JApiHasChangeStatus {
 	private final Optional<String> oldTypeOptional;
 	private final Optional<String> newTypeOptional;
 	private final JApiChangeStatus changeStatus;
@@ -27,6 +27,7 @@ public class JApiType {
 		return newTypeOptional;
 	}
 
+	@Override
 	@XmlAttribute(name = "changeStatus")
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;

--- a/japicmp/src/main/java/japicmp/output/extapi/jpa/model/JpaName.java
+++ b/japicmp/src/main/java/japicmp/output/extapi/jpa/model/JpaName.java
@@ -2,11 +2,12 @@ package japicmp.output.extapi.jpa.model;
 
 import japicmp.util.Optional;
 import japicmp.model.JApiChangeStatus;
+import japicmp.model.JApiHasChangeStatus;
 import japicmp.util.OptionalHelper;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
-public class JpaName {
+public class JpaName implements JApiHasChangeStatus {
 	private final Optional<String> newName;
 	private final Optional<String> oldName;
 	private final JApiChangeStatus changeStatus;
@@ -17,6 +18,7 @@ public class JpaName {
 		this.changeStatus = changeStatus;
 	}
 
+	@Override
 	@XmlAttribute(name = "changeStatus")
 	public JApiChangeStatus getChangeStatus() {
 		return changeStatus;


### PR DESCRIPTION
I noticed that several classes have a method `public JApiChangeStatus getChangeStatus()` but were not advertised as `JApiHasChangeStatus` implementors.