### PR TITLE
Extract string constants from `SemverOut` so they can be reused

### DIFF
--- a/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/output/SemverOutIntegTest.java
+++ b/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/output/SemverOutIntegTest.java
@@ -24,63 +24,63 @@ public class SemverOutIntegTest {
 	public void testSemver001_implementation_of_method_changes() {
 		String lastPackage = "semver001.a";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("0.0.1", string);
+		assertEquals(SemverOut.SEMVER_PATCH, string);
 	}
 
 	@Test
 	public void testSemver010_added_deprecated_annotation() {
 		String lastPackage = "semver010.a";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("0.1.0", string);
+		assertEquals(SemverOut.SEMVER_MINOR, string);
 	}
 
 	@Test
 	public void testSemver100_change_method() {
 		String lastPackage = "semver100.a";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string);
+		assertEquals(SemverOut.SEMVER_MAJOR, string);
 	}
 
 	@Test
 	public void testSemver100_reduce_class_visibility() {
 		String lastPackage = "semver100.b";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string);
+		assertEquals(SemverOut.SEMVER_MAJOR, string);
 	}
 
 	@Test
 	public void testSemver100_reduce_method_visibility() {
 		String lastPackage = "semver100.c";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string);
+		assertEquals(SemverOut.SEMVER_MAJOR, string);
 	}
 
 	@Test
 	public void testSemver100_superclass_with_field() {
 		String lastPackage = "semver100.d";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string);
+		assertEquals(SemverOut.SEMVER_MAJOR, string);
 	}
 
 	@Test
 	public void testSemver_class_with_private_final_field() {
 		String lastPackage = "semver.finalfield";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("0.0.1", string);
+		assertEquals(SemverOut.SEMVER_PATCH, string);
 	}
 
 	@Test
 	public void testSemver_class_with_public_final_method() {
 		String lastPackage = "semver.finalpublicmethod";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string);
+		assertEquals(SemverOut.SEMVER_MAJOR, string);
 	}
 
 	@Test
 	public void testSemver_private_inner_class_changes() {
 		String lastPackage = "semver.privateinnerclass";
 		String string = getSemverDiff(lastPackage);
-		assertEquals("1.0.0", string); // private inner class becomes package protected -> change is binary incompatible
+		assertEquals(SemverOut.SEMVER_MAJOR, string); // private inner class becomes package protected -> change is binary incompatible
 	}
 
 	private String getSemverDiff(String lastPackage) {

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -142,22 +142,22 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 						});
 
 					String semver = semverOut.generate();
-					if (changeType == SemanticVersion.ChangeType.MINOR && semver.equals("1.0.0")) {
+					if (changeType == SemanticVersion.ChangeType.MINOR && semver.equals(SemverOut.SEMVER_MAJOR)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a minor change but binary incompatible changes found.");
 					}
-					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals("1.0.0")) {
+					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals(SemverOut.SEMVER_MAJOR)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a patch change but binary incompatible changes found.");
 					}
-					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals("0.1.0")) {
+					if (changeType == SemanticVersion.ChangeType.PATCH && semver.equals(SemverOut.SEMVER_MINOR)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate a patch change but binary compatible changes found.");
 					}
-					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("1.0.0")) {
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals(SemverOut.SEMVER_MAJOR)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but binary incompatible changes found.");
 					}
-					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("0.1.0")) {
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals(SemverOut.SEMVER_MINOR)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but binary compatible changes found.");
 					}
-					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals("0.0.1")) {
+					if (changeType == SemanticVersion.ChangeType.UNCHANGED && semver.equals(SemverOut.SEMVER_PATCH)) {
 						throw new JApiCmpException(JApiCmpException.Reason.IncompatibleChange, "Versions of archives indicate no API changes but found API changes.");
 					}
 				} else {

--- a/japicmp/src/main/java/japicmp/output/semver/SemverOut.java
+++ b/japicmp/src/main/java/japicmp/output/semver/SemverOut.java
@@ -28,6 +28,11 @@ import japicmp.util.ModifierHelper;
 
 public class SemverOut extends OutputGenerator<String> {
 
+	public static final String SEMVER_MAJOR = "1.0.0";
+	public static final String SEMVER_MINOR = "0.1.0";
+	public static final String SEMVER_PATCH = "0.0.1";
+	public static final String SEMVER_COMPATIBLE = "0.0.0";
+
 	private Listener m_Listener = Listener.NULL;
 
 	public SemverOut(Options options, List<JApiClass> jApiClasses) {
@@ -80,13 +85,13 @@ public class SemverOut extends OutputGenerator<String> {
 		});
 		ImmutableSet<JApiSemanticVersionLevel> build = builder.build();
 		if (build.contains(JApiSemanticVersionLevel.MAJOR)) {
-			return "1.0.0";
+			return SEMVER_MAJOR;
 		} else if (build.contains(JApiSemanticVersionLevel.MINOR)) {
-			return "0.1.0";
+			return SEMVER_MINOR;
 		} else if (build.contains(JApiSemanticVersionLevel.PATCH)) {
-			return "0.0.1";
+			return SEMVER_PATCH;
 		} else if (build.isEmpty()) {
-			return "0.0.0";
+			return SEMVER_COMPATIBLE;
 		} else {
 			return "N/A";
 		}

--- a/japicmp/src/test/java/japicmp/output/semver/SemverOutTest.java
+++ b/japicmp/src/test/java/japicmp/output/semver/SemverOutTest.java
@@ -33,6 +33,6 @@ public class SemverOutTest {
 		Options options = Options.newDefault();
 		SemverOut semverOut = new SemverOut(options, jApiClasses);
 		String output = semverOut.generate();
-		assertThat(output, is("0.0.0"));
+		assertThat(output, is(SemverOut.SEMVER_COMPATIBLE));
 	}
 }


### PR DESCRIPTION
According to [Sonar rules](https://rules.sonarsource.com/java/RSPEC-1192/ "String literals should not be duplicated"):

> _Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all occurrences._

The rationale behind this PR is that I'm working on a new output generator for japicmp that would benefit from `SemverOut` results being defined as constants.