### PR TITLE
Fix for issue #359 - >=0.16.0: Cannot compare versions because the number of old versions is different than the number of new versions

### DIFF
--- a/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
+++ b/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
@@ -296,7 +296,6 @@ public class JarArchiveComparator {
 						LOGGER.fine(String.format("Adding class '%s' with jar name '%s' to list.", ctClass.getName(), ctClass.getName()));
 					}
 				} else {
-					classPool.remove(ctClass);
 					if (LOGGER.isLoggable(Level.FINE)) {
 						LOGGER.fine(String.format("Ignoring class '%s' with jar name '%s'.", ctClass.getName(), ctClass.getName()));
 					}


### PR DESCRIPTION
Issue was created in pull: https://github.com/siom79/japicmp/pull/333

It causes to not work correctly in some cases in big, multi module projects. Case was described by @martinaldrin in https://github.com/siom79/japicmp/issues/359.

Issue can be solved by changing on line as is was before pull #333. Please review @siom79, and consider merging and deploying, for now we are blocked and we cannot go over version 0.15.6 in our projects.
