### PR TITLE
Refactor interface hierarchy to avoid unnecessary casting

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -77,7 +77,7 @@ public class CompatibilityChanges {
 	private void checkIfGenericTemplatesHaveChanged(JApiHasGenericTemplates jApiHasGenericTemplates) {
 		for (JApiGenericTemplate jApiGenericTemplate : jApiHasGenericTemplates.getGenericTemplates()) {
 			if (jApiGenericTemplate.getChangeStatus() != JApiChangeStatus.UNCHANGED) {
-				((JApiCompatibility)jApiHasGenericTemplates).getCompatibilityChanges().add(JApiCompatibilityChange.CLASS_GENERIC_TEMPLATE_CHANGED);
+				jApiHasGenericTemplates.getCompatibilityChanges().add(JApiCompatibilityChange.CLASS_GENERIC_TEMPLATE_CHANGED);
 				break;
 			}
 		}
@@ -86,7 +86,7 @@ public class CompatibilityChanges {
 			if (changeStatus == JApiChangeStatus.MODIFIED || changeStatus == JApiChangeStatus.UNCHANGED) {
 				if (!SignatureParser.equalGenericTypes(jApiGenericTemplate.getOldGenericTypes(), jApiGenericTemplate.getNewGenericTypes())) {
 					jApiGenericTemplate.getCompatibilityChanges().add(JApiCompatibilityChange.CLASS_GENERIC_TEMPLATE_GENERICS_CHANGED);
-					((JApiCompatibility)jApiHasGenericTemplates).getCompatibilityChanges().add(JApiCompatibilityChange.CLASS_GENERIC_TEMPLATE_GENERICS_CHANGED);
+					jApiHasGenericTemplates.getCompatibilityChanges().add(JApiCompatibilityChange.CLASS_GENERIC_TEMPLATE_GENERICS_CHANGED);
 					break;
 				}
 			}
@@ -470,7 +470,7 @@ public class CompatibilityChanges {
 		for (JApiAnnotation annotation : jApiHasAnnotations.getAnnotations()) {
 			if (annotation.getChangeStatus() == JApiChangeStatus.NEW || annotation.getChangeStatus() == JApiChangeStatus.MODIFIED) {
 				if (annotation.getFullyQualifiedName().equals(Deprecated.class.getName())) {
-					addCompatibilityChange((JApiCompatibility) jApiHasAnnotations, JApiCompatibilityChange.ANNOTATION_DEPRECATED_ADDED);
+					addCompatibilityChange(jApiHasAnnotations, JApiCompatibilityChange.ANNOTATION_DEPRECATED_ADDED);
 				}
 			}
 		}

--- a/japicmp/src/main/java/japicmp/model/JApiHasAnnotations.java
+++ b/japicmp/src/main/java/japicmp/model/JApiHasAnnotations.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Implemented by all elements that can have annotations.
  */
-public interface JApiHasAnnotations {
+public interface JApiHasAnnotations extends JApiCompatibility {
 	/**
 	 * Returns a list of annotations as {@link japicmp.model.JApiAnnotation}.
 	 *

--- a/japicmp/src/main/java/japicmp/model/JApiHasGenericTemplates.java
+++ b/japicmp/src/main/java/japicmp/model/JApiHasGenericTemplates.java
@@ -2,6 +2,6 @@ package japicmp.model;
 
 import java.util.List;
 
-public interface JApiHasGenericTemplates {
+public interface JApiHasGenericTemplates extends JApiCompatibility {
 	List<JApiGenericTemplate> getGenericTemplates();
 }


### PR DESCRIPTION
Given that:

1. All current implementations of `JApiHasAnnotations` and `JApiHasGenericTemplates` implement `JApiCompatibility` as well.
2. Code in `CompatibilityChanges` assumes that any such instances can be safely casted to `JApiCompatibility`.

I believe that we can say that, _by definition_, all instances of `JApiHasAnnotations` and `JApiHasGenericTemplates` _must be_ a `JApiCompatibility`.

So I think these two interfaces should extend `JApiCompatibility` to clarify this relationship and to avoid unnecessary type casting.