### PR TITLE
Correctly set a superclass' corresponding class

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -221,6 +221,7 @@ public class CompatibilityChanges {
 				}
 				classMap.put(foundClass.getFullyQualifiedName(), foundClass);
 			}
+			superclass.setJApiClass(foundClass);
 			T returnValue = onSuperclassCallback.callback(foundClass, classMap, superclass.getChangeStatus());
 			returnValues.add(returnValue);
 			forAllSuperclasses(foundClass, classMap, returnValues, onSuperclassCallback);

--- a/japicmp/src/main/java/japicmp/model/JApiClass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClass.java
@@ -293,7 +293,6 @@ public class JApiClass implements JApiHasModifiers, JApiHasChangeStatus, JApiHas
 				}
 			}
 		}
-		retVal.setJApiClass(this);
 		return retVal;
 	}
 

--- a/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
@@ -130,7 +130,7 @@ public class JApiSuperclass implements JApiHasChangeStatus, JApiCompatibility {
 		return this.compatibilityChanges;
 	}
 
-	void setJApiClass(JApiClass jApiClass) {
+	public void setJApiClass(JApiClass jApiClass) {
 		this.correspondingJApiClass = Optional.of(jApiClass);
 	}
 

--- a/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
@@ -134,6 +134,10 @@ public class JApiSuperclass implements JApiHasChangeStatus, JApiCompatibility {
 		this.correspondingJApiClass = Optional.of(jApiClass);
 	}
 
+	public Optional<JApiClass> getCorrespondingJApiClass() {
+		return correspondingJApiClass;
+	}
+
 	/**
 	 * Returns the {@link japicmp.model.JApiClass} this superclass belongs to.
 	 * @return the JApiClass this superclass belongs to.

--- a/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
+++ b/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
@@ -207,6 +207,8 @@ public class CompatibilityChangesTest {
 		assertThat(jApiClass.getSuperclass().getCompatibilityChanges(), hasItem(JApiCompatibilityChange.SUPERCLASS_ADDED));
 		assertThat(jApiClass.isBinaryCompatible(), is(true));
 		JApiSuperclass superclass = jApiClass.getSuperclass();
+		assertEquals("japicmp.Test", superclass.getJApiClassOwning().getFullyQualifiedName());
+		assertEquals("japicmp.Superclass", superclass.getCorrespondingJApiClass().get().getFullyQualifiedName());
 		assertThat(superclass.isBinaryCompatible(), is(true));
 		assertThat(superclass.getCompatibilityChanges(), hasItem(JApiCompatibilityChange.SUPERCLASS_ADDED));
 	}
@@ -233,6 +235,8 @@ public class CompatibilityChangesTest {
 		assertThat(jApiClass.getCompatibilityChanges().size(), is(0));
 		assertThat(jApiClass.isBinaryCompatible(), is(true));
 		JApiSuperclass superclass = jApiClass.getSuperclass();
+		assertEquals("japicmp.Test", superclass.getJApiClassOwning().getFullyQualifiedName());
+		assertEquals("java.lang.Object", superclass.getCorrespondingJApiClass().get().getFullyQualifiedName());
 		assertThat(superclass.isBinaryCompatible(), is(true));
 		assertThat(superclass.getCompatibilityChanges().size(), is(0));
 	}
@@ -370,6 +374,8 @@ public class CompatibilityChangesTest {
 		assertThat(jApiMethod.getCompatibilityChanges(), hasItem(JApiCompatibilityChange.METHOD_REMOVED));
 		assertThat(jApiMethod.isBinaryCompatible(), is(false));
 		JApiSuperclass superclass = jApiClass.getSuperclass();
+		assertEquals("japicmp.Test", superclass.getJApiClassOwning().getFullyQualifiedName());
+		assertEquals("java.lang.Object", superclass.getCorrespondingJApiClass().get().getFullyQualifiedName());
 		assertThat(superclass.isBinaryCompatible(), is(true));
 		assertThat(superclass.getCompatibilityChanges().size(), is(0));
 	}


### PR DESCRIPTION
I found what I believe is a small bug in the source code which is assigning the wrong `correspondingJApiClass` to a `JApiSuperclass`.