### PR TITLE
Initialize the corresponding class of a NEW implemented interface

### DIFF
--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -803,8 +803,8 @@ public class CompatibilityChanges {
 				if (interfaceClass == null) {
 					interfaceClass = loadClass(implementedInterface.getFullyQualifiedName(), EnumSet.allOf(Classpath.class));
 				}
+				implementedInterface.setJApiClass(interfaceClass);
 				if (implementedInterface.getChangeStatus() == JApiChangeStatus.MODIFIED || implementedInterface.getChangeStatus() == JApiChangeStatus.UNCHANGED) {
-					implementedInterface.setJApiClass(interfaceClass);
 					checkIfMethodsHaveChangedIncompatible(interfaceClass, classMap);
 					checkIfFieldsHaveChangedIncompatible(interfaceClass, classMap);
 				} else if (implementedInterface.getChangeStatus() == JApiChangeStatus.NEW) {

--- a/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
+++ b/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
@@ -77,6 +77,10 @@ public class JApiImplementedInterface implements JApiHasChangeStatus, JApiCompat
 		this.correspondingJApiClass = Optional.of(jApiClass);
 	}
 
+	public Optional<JApiClass> getCorrespondingJApiClass() {
+		return correspondingJApiClass;
+	}
+
 	@XmlTransient
 	public CtClass getCtClass() {
 		return ctClass;

--- a/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
+++ b/japicmp/src/test/java/japicmp/compat/CompatibilityChangesTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static japicmp.util.Helper.*;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
@@ -2292,6 +2293,10 @@ public class CompatibilityChangesTest {
 		JApiClass jApiClass = getJApiClass(jApiClasses, "com.acme.japicmp.NewOperator");
 		assertThat(jApiClass.getCompatibilityChanges(), hasItem(new JApiCompatibilityChange(JApiCompatibilityChangeType.INTERFACE_ADDED)));
 		assertThat(jApiClass.getCompatibilityChanges(), not(hasItem(new JApiCompatibilityChange(JApiCompatibilityChangeType.METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE))));
+		JApiImplementedInterface implementedInterface = jApiClass.getInterfaces().stream().filter(i -> i.getFullyQualifiedName().equals("java.util.function.UnaryOperator")).findFirst().orElse(null);
+		assertThat(implementedInterface, notNullValue());
+		assertThat(implementedInterface.getCorrespondingJApiClass().isPresent(), is(true));
+		assertThat(implementedInterface.getCorrespondingJApiClass().get().getFullyQualifiedName(), is("java.util.function.UnaryOperator"));
 	}
 
 	@Test


### PR DESCRIPTION
Currently, an implemented interface's corresponding class is set only when its change status is `MODIFIED` or `UNCHANGED`. This pull request also initializes it when the implemented interface is `NEW`.
