### PR TITLE
Optionally take changes to annotations into account

### DIFF
--- a/japicmp-testbase/japicmp-test-ant-task/pom.xml
+++ b/japicmp-testbase/japicmp-test-ant-task/pom.xml
@@ -93,7 +93,7 @@
 								</path>
 
 								<taskdef resource="japicmp/ant/antlib.xml" classpathref="task.classpath" />
-								<japicmp oldjar="${project.build.directory}/guava-18.0.jar" newjar="${project.build.directory}/guava-19.0.jar" oldclasspath="old.classpath" newclasspath="new.classpath" onlyBinaryIncompatible="false" onlyModified="true" />
+								<japicmp oldjar="${project.build.directory}/guava-18.0.jar" newjar="${project.build.directory}/guava-19.0.jar" oldclasspath="old.classpath" newclasspath="new.classpath" onlyBinaryIncompatible="false" onlyModified="true" noAnnotations="true" />
 
 							</target>
 						</configuration>

--- a/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
+++ b/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java
@@ -60,12 +60,12 @@ public class CompatibilityChanges {
 		// section 13.4.4 of "Java Language Specification" SE7
 		checkIfSuperclassesOrInterfacesChangedIncompatible(jApiClass, classMap);
 		checkIfMethodsHaveChangedIncompatible(jApiClass, classMap);
-		checkIfConstructorsHaveChangedIncompatible(jApiClass);
+		checkIfConstructorsHaveChangedIncompatible(jApiClass, classMap);
 		checkIfFieldsHaveChangedIncompatible(jApiClass, classMap);
 		if (jApiClass.getClassType().getChangeStatus() == JApiChangeStatus.MODIFIED) {
 			addCompatibilityChange(jApiClass, JApiCompatibilityChangeType.CLASS_TYPE_CHANGED);
 		}
-		checkIfAnnotationDeprecatedAdded(jApiClass);
+		checkIfAnnotationsChanged(jApiClass, classMap);
 		if (hasModifierLevelDecreased(jApiClass)) {
 			addCompatibilityChange(jApiClass, JApiCompatibilityChangeType.CLASS_LESS_ACCESSIBLE);
 		}
@@ -193,7 +193,7 @@ public class CompatibilityChanges {
 			if (isNotPrivate(field) && field.getType().hasChanged()) {
 				addCompatibilityChange(field, JApiCompatibilityChangeType.FIELD_TYPE_CHANGED);
 			}
-			checkIfAnnotationDeprecatedAdded(field);
+			checkIfAnnotationsChanged(field, classMap);
 			checkIfFieldGenericsChanged(field);
 		}
 	}
@@ -292,7 +292,7 @@ public class CompatibilityChanges {
 		return matches;
 	}
 
-	private void checkIfConstructorsHaveChangedIncompatible(JApiClass jApiClass) {
+	private void checkIfConstructorsHaveChangedIncompatible(JApiClass jApiClass, Map<String, JApiClass> classMap) {
 		for (JApiConstructor constructor : jApiClass.getConstructors()) {
 			// section 13.4.6 of "Java Language Specification" SE7
 			if (isNotPrivate(constructor) && constructor.getChangeStatus() == JApiChangeStatus.REMOVED) {
@@ -305,7 +305,7 @@ public class CompatibilityChanges {
 				}
 			}
 			checkIfExceptionIsNowChecked(constructor);
-			checkIfAnnotationDeprecatedAdded(constructor);
+			checkIfAnnotationsChanged(constructor, classMap);
 			checkIfVarargsChanged(constructor);
 			checkIfParametersGenericsChanged(constructor);
 			if (jApiClass.getChangeStatus().isNotNewOrRemoved()) {
@@ -425,7 +425,7 @@ public class CompatibilityChanges {
 			}
 			checkAbstractMethod(jApiClass, classMap, method);
 			checkIfExceptionIsNowChecked(method);
-			checkIfAnnotationDeprecatedAdded(method);
+			checkIfAnnotationsChanged(method, classMap);
 			checkIfVarargsChanged(method);
 			checkIfParametersGenericsChanged(method);
 			if (method.getChangeStatus().isNotNewOrRemoved()) {
@@ -471,11 +471,29 @@ public class CompatibilityChanges {
 		}
 	}
 
-	private void checkIfAnnotationDeprecatedAdded(JApiHasAnnotations jApiHasAnnotations) {
+	private void checkIfAnnotationsChanged(JApiHasAnnotations jApiHasAnnotations, Map<String, JApiClass> classMap) {
 		for (JApiAnnotation annotation : jApiHasAnnotations.getAnnotations()) {
-			if (annotation.getChangeStatus() == JApiChangeStatus.NEW || annotation.getChangeStatus() == JApiChangeStatus.MODIFIED) {
-				if (annotation.getFullyQualifiedName().equals(Deprecated.class.getName())) {
-					addCompatibilityChange(jApiHasAnnotations, JApiCompatibilityChangeType.ANNOTATION_DEPRECATED_ADDED);
+			final JApiChangeStatus status = annotation.getChangeStatus();
+			if (status == JApiChangeStatus.REMOVED) {
+				addCompatibilityChange(jApiHasAnnotations, JApiCompatibilityChangeType.ANNOTATION_REMOVED);
+			} else {
+				final boolean isNoAnnotations = this.jarArchiveComparator.getJarArchiveComparatorOptions().isNoAnnotations();
+				final boolean isDeprecated = annotation.getFullyQualifiedName().equals(Deprecated.class.getName());
+				final JApiClass annotationClass;
+				if (isNoAnnotations && !isDeprecated) {
+					annotationClass = null;
+				} else {
+					annotationClass = classMap.computeIfAbsent(annotation.getFullyQualifiedName(), fqn -> loadClass(fqn, EnumSet.allOf(Classpath.class)));
+					annotation.setJApiClass(annotationClass);
+				}
+				if (status == JApiChangeStatus.NEW || status == JApiChangeStatus.MODIFIED) {
+					addCompatibilityChange(jApiHasAnnotations, isDeprecated ? JApiCompatibilityChangeType.ANNOTATION_DEPRECATED_ADDED : JApiCompatibilityChangeType.ANNOTATION_ADDED);
+				} else if (annotationClass != null) {
+					checkIfMethodsHaveChangedIncompatible(annotationClass, classMap);
+					checkIfFieldsHaveChangedIncompatible(annotationClass, classMap);
+					if (!annotationClass.isSourceCompatible() || !annotationClass.isBinaryCompatible()) {
+						addCompatibilityChange(jApiHasAnnotations, JApiCompatibilityChangeType.ANNOTATION_MODIFIED_INCOMPATIBLE);
+					}
 				}
 			}
 		}

--- a/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
@@ -21,6 +21,7 @@ public class JApiAnnotation implements JApiHasChangeStatus, JApiCompatibility {
 	private final Optional<Annotation> newAnnotation;
 	private final List<JApiAnnotationElement> elements = new LinkedList<>();
 	private final JApiChangeStatus changeStatus;
+	private Optional<JApiClass> correspondingJApiClass = Optional.absent();
 
 	public JApiAnnotation(String fullyQualifiedName, Optional<Annotation> oldAnnotation, Optional<Annotation> newAnnotation, JApiChangeStatus changeStatus) {
 		this.fullyQualifiedName = fullyQualifiedName;
@@ -132,6 +133,14 @@ public class JApiAnnotation implements JApiHasChangeStatus, JApiCompatibility {
 	@XmlAttribute(name = "fullyQualifiedName")
 	public String getFullyQualifiedName() {
 		return fullyQualifiedName;
+	}
+
+	public void setJApiClass(JApiClass jApiClass) {
+		this.correspondingJApiClass = Optional.of(jApiClass);
+	}
+
+	public Optional<JApiClass> getCorrespondingJApiClass() {
+		return correspondingJApiClass;
 	}
 
 	@XmlTransient

--- a/japicmp/src/main/java/japicmp/model/JApiCompatibilityChangeType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiCompatibilityChangeType.java
@@ -5,7 +5,10 @@ import javax.xml.bind.annotation.XmlEnum;
 
 @XmlEnum
 public enum JApiCompatibilityChangeType {
+	ANNOTATION_ADDED(true, true, JApiSemanticVersionLevel.PATCH),
 	ANNOTATION_DEPRECATED_ADDED(true, true, JApiSemanticVersionLevel.MINOR),
+	ANNOTATION_MODIFIED_INCOMPATIBLE(true, true, JApiSemanticVersionLevel.PATCH),
+	ANNOTATION_REMOVED(true, true, JApiSemanticVersionLevel.PATCH),
 	CLASS_REMOVED(false, false, JApiSemanticVersionLevel.MAJOR),
 	CLASS_NOW_ABSTRACT(false, false, JApiSemanticVersionLevel.MAJOR),
 	CLASS_NOW_FINAL(false, false, JApiSemanticVersionLevel.MAJOR),

--- a/japicmp/src/test/java/japicmp/util/CtAnnotationBuilder.java
+++ b/japicmp/src/test/java/japicmp/util/CtAnnotationBuilder.java
@@ -1,0 +1,22 @@
+package japicmp.util;
+
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+
+public class CtAnnotationBuilder {
+	private String name = "japicmp.Test";
+
+	public CtAnnotationBuilder name(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public CtClass addToClassPool(ClassPool classPool) {
+		return classPool.makeAnnotation(this.name);
+	}
+
+	public static CtAnnotationBuilder create() {
+		return new CtAnnotationBuilder();
+	}
+}


### PR DESCRIPTION
Resolves:

-  https://github.com/siom79/japicmp/issues/385

Related pull request:

- https://github.com/siom79/japicmp/pull/386

This is an alternative approach, in which changes to annotations will be ignored if option `--no-annotations` is set.
