### PR TITLE
fix: check changes in return types

### DIFF
--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -635,6 +635,12 @@
 										<sourceCompatible>true</sourceCompatible>
 										<semanticVersionLevel>PATCH</semanticVersionLevel>
 									</overrideCompatibilityChangeParameter>
+									<overrideCompatibilityChangeParameter>
+										<compatibilityChange>METHOD_RETURN_TYPE_GENERICS_CHANGED</compatibilityChange>
+										<binaryCompatible>true</binaryCompatible>
+										<sourceCompatible>true</sourceCompatible>
+										<semanticVersionLevel>PATCH</semanticVersionLevel>
+									</overrideCompatibilityChangeParameter>
 								</overrideCompatibilityChangeParameters>
 								<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
 								<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -106,26 +106,26 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 					final SemanticVersion.ChangeType changeType = changeTypeOptional.get();
 
 					SemverOut semverOut = new SemverOut(options, jApiClasses, (change, semanticVersionLevel) -> {
-						switch (semanticVersionLevel) {
-							case MAJOR:
-								if (changeType.ordinal() > SemanticVersion.ChangeType.MAJOR.ordinal()) {
-									warn("Incompatibility detected: Requires semantic version level " + semanticVersionLevel + ": " + change);
-								}
-								break;
-							case MINOR:
-								if (changeType.ordinal() > SemanticVersion.ChangeType.MINOR.ordinal()) {
-									warn("Incompatibility detected: Requires semantic version level	 " + semanticVersionLevel + ": " + change);
-								}
-								break;
-							case PATCH:
-								if (changeType.ordinal() > SemanticVersion.ChangeType.PATCH.ordinal()) {
-									warn("Incompatibility detected: Requires semantic version level	 " + semanticVersionLevel + ": " + change);
-								}
-								break;
-							default:
-								// Ignore
-						}
-					});
+                        switch(semanticVersionLevel) {
+                        case MAJOR:
+                            if (changeType.ordinal() > SemanticVersion.ChangeType.MAJOR.ordinal()) {
+                                warn("Incompatibility detected: Requires semantic version level " + semanticVersionLevel + ": " + change);
+                            }
+                            break;
+                        case MINOR:
+                            if (changeType.ordinal() > SemanticVersion.ChangeType.MINOR.ordinal()) {
+                                warn("Incompatibility detected: Requires semantic version level	 " + semanticVersionLevel + ": " + change);
+                            }
+                            break;
+                        case PATCH:
+                            if (changeType.ordinal() > SemanticVersion.ChangeType.PATCH.ordinal()) {
+                                warn("Incompatibility detected: Requires semantic version level	 " + semanticVersionLevel + ": " + change);
+                            }
+                            break;
+                        default:
+                            // Ignore
+                        }
+                    });
 
 					String semver = semverOut.generate();
 					if (changeType == SemanticVersion.ChangeType.MINOR && semver.equals(SemverOut.SEMVER_MAJOR)) {
@@ -311,7 +311,7 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 			private boolean breakBuildIfCausedByExclusion(JApiImplementedInterface jApiImplementedInterface) {
 				if (!breakBuildIfCausedByExclusion) {
 					CtClass ctClass = jApiImplementedInterface.getCtClass();
-					return !classExcluded(ctClass);
+                    return !classExcluded(ctClass);
 				}
 				return true;
 			}
@@ -406,7 +406,7 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 					Optional<CtClass> newSuperclassOptional = jApiSuperclass.getNewSuperclass();
 					if (newSuperclassOptional.isPresent()) {
 						CtClass ctClass = newSuperclassOptional.get();
-						return !classExcluded(ctClass);
+                        return !classExcluded(ctClass);
 					}
 				}
 				return true;

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -229,6 +229,23 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 							.append(")").append(":").append(change.getType().name());
 					}
 				}
+
+				for (JApiCompatibilityChange change : jApiMethod.getReturnType().getCompatibilityChanges()) {
+					if (!change.isBinaryCompatible() || !change.isSourceCompatible()) {
+						if (!change.isBinaryCompatible() && options.isErrorOnBinaryIncompatibility()) {
+							breakBuildResult.binaryIncompatibleChanges = true;
+						}
+						if (!change.isSourceCompatible() &&  options.isErrorOnSourceIncompatibility()) {
+							breakBuildResult.sourceIncompatibleChanges = true;
+						}
+						if (sb.length() > 1) {
+							sb.append(',');
+						}
+						sb.append(jApiMethod.getjApiClass().getFullyQualifiedName()).append(".")
+							.append(jApiMethod.getName()).append("(").append(methodParameterToList(jApiMethod))
+							.append(")").append(":").append(change.getType().name());
+					}
+				}
 			}
 
 			private boolean breakBuildIfCausedByExclusion(JApiMethod jApiMethod) {


### PR DESCRIPTION
I noticed that the maven plugin does not break on `METHOD_RETURN_TYPE_GENERICS_CHANGED`. 

This looked to be because method is not given a JApiCompatibilityChange, but instead the return type of the method is given a JApiCompatibilityChange. 

https://github.com/siom79/japicmp/blob/68727ed928502f0062cab4177eea6efe21c2e697/japicmp/src/main/java/japicmp/compat/CompatibilityChanges.java#L453 

So added a check for the compatibility changes in the return types of methods.