### PR TITLE
Add markdown report to github summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
       shell: bash
       run: |
         mvn -B package
-        cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >> GITHUB_STEP_SUMMARY
+        cat pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,5 @@ jobs:
       shell: bash
       run: |
         mvn -B install
-        mvn -pl japicmp site:site
+        mvn -pl japicmp site:site -Dspotbugs.skip=true
         cat japicmp/target/site/japicmp.md  >$GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Build with Maven
       shell: bash
       run: |
-        mvn -B verify
+        mvn -B install
         mvn -pl japicmp site:site
         cat japicmp/target/site/japicmp.md  >$GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,4 @@ jobs:
       shell: bash
       run: |
         mvn -B install
-        mvn -pl japicmp site:site -Dspotbugs.skip=true
-        cat japicmp/target/site/japicmp.md  >$GITHUB_STEP_SUMMARY
+        cat japicmp/target/japicmp/github-job-summary.md  >$GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       shell: bash
       run: |
         mvn -B verify
-        cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >$GITHUB_STEP_SUMMARY
+        mvn -pl japicmp site:site
+        cat japicmp/target/site/japicmp.md  >$GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,6 @@ jobs:
     - name: Build with Maven
       run: mvn -B package
     - name: japicmp report in Job Summary
-      run:  mvn -Pjapicmp com.github.siom79.japicmp:japicmp-maven-plugin:cmp && \
+      run:  cd japicmp && \
+        mvn -Pjapicmp com.github.siom79.japicmp:japicmp-maven-plugin:cmp && \
         cat ./japicmp/target/japicmp/japicmp.md >> GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,4 @@ jobs:
     - name: Build with Maven
       run: mvn -B package
     - name: japicmp report in Job Summary
-      run:  cd japicmp && \
-        mvn -Pjapicmp com.github.siom79.japicmp:japicmp-maven-plugin:cmp && \
-        cat ./japicmp/target/japicmp/japicmp.md >> GITHUB_STEP_SUMMARY
+      run:  cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >> GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: maven
     - name: Build with Maven
-      run: mvn -B package && \
+      shell: bash
+      run: |
+        mvn -B package
         cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >> GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17, 18, 19, 21, 22 ]
+        java: [ 8, 11, 17, 21, 22 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,5 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: maven
     - name: Build with Maven
-      run: mvn -B package
-    - name: japicmp report in Job Summary
-      run:  cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >> GITHUB_STEP_SUMMARY
+      run: mvn -B package && \
+        cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >> GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
     - name: Build with Maven
       shell: bash
       run: |
-        mvn -B package
-        cat pom.xml
+        mvn -B verify
+        cat ./japicmp-testbase/japicmp-test-maven-plugin/target/japicmp/github-job-summary.md >$GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package
+    - name: japicmp report in Job Summary
+      run: cat ./japicmp/target/japicmp/japicmp.md >> GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,5 @@ jobs:
     - name: Build with Maven
       run: mvn -B package
     - name: japicmp report in Job Summary
-      run: cat ./japicmp/target/japicmp/japicmp.md >> GITHUB_STEP_SUMMARY
+      run:  mvn -Pjapicmp com.github.siom79.japicmp:japicmp-maven-plugin:cmp && \
+        cat ./japicmp/target/japicmp/japicmp.md >> GITHUB_STEP_SUMMARY

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -80,26 +80,6 @@
 				<version>${project.version}</version>
 				<executions>
 					<execution>
-						<id>github-job-summary</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>cmp</goal>
-						</goals>
-						<configuration>
-							<newVersion>
-								<dependency>
-									<groupId>com.github.siom79.japicmp</groupId>
-									<artifactId>japicmp</artifactId>
-									<version>${project.version}</version>
-								</dependency>
-							</newVersion>
-							<parameter>
-								<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
-								<onlyModified>false</onlyModified>
-							</parameter>
-						</configuration>
-					</execution>
-					<execution>
 						<id>single-version</id>
 						<phase>pre-integration-test</phase>
 						<goals>

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -80,6 +80,25 @@
 				<version>${project.version}</version>
 				<executions>
 					<execution>
+						<id>github-job-summary</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+						<configuration>
+							<newVersion>
+								<dependency>
+									<groupId>com.github.siom79.japicmp</groupId>
+									<artifactId>japicmp</artifactId>
+									<version>${project.version}</version>
+								</dependency>
+							</newVersion>
+							<parameter>
+								<onlyModified>false</onlyModified>
+							</parameter>
+						</configuration>
+					</execution>
+					<execution>
 						<id>single-version</id>
 						<phase>pre-integration-test</phase>
 						<goals>

--- a/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
+++ b/japicmp-testbase/japicmp-test-maven-plugin/pom.xml
@@ -94,6 +94,7 @@
 								</dependency>
 							</newVersion>
 							<parameter>
+								<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
 								<onlyModified>false</onlyModified>
 							</parameter>
 						</configuration>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -209,37 +209,5 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>japicmp</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.github.siom79.japicmp</groupId>
-						<artifactId>japicmp-maven-plugin</artifactId>
-						<version>${project.version}</version>
-						<configuration>
-							<newVersion>
-								<file>
-									<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
-								</file>
-							</newVersion>
-							<parameter>
-								<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
-								<onlyModified>true</onlyModified>
-							</parameter>
-							<skip>false</skip>
-						</configuration>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>cmp</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 </project>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -189,17 +189,6 @@
 					</plugin>
 				</plugins>
 			</build>
-			<reporting>
-				<plugins>
-					<plugin>
-						<groupId>com.github.spotbugs</groupId>
-						<artifactId>spotbugs-maven-plugin</artifactId>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</plugin>
-				</plugins>
-			</reporting>
 		</profile>
 		<profile>
 			<id>java-9</id>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -189,6 +189,17 @@
 					</plugin>
 				</plugins>
 			</build>
+			<reporting>
+				<plugins>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</reporting>
 		</profile>
 		<profile>
 			<id>java-9</id>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -113,31 +113,6 @@
 					</argLine>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-				<version>${project.version}</version>
-				<configuration>
-					<newVersion>
-						<file>
-							<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
-						</file>
-					</newVersion>
-					<parameter>
-						<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
-						<onlyModified>true</onlyModified>
-					</parameter>
-					<skip>false</skip>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>cmp</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 
@@ -230,6 +205,38 @@
 								@{argLine}
 							</argLine>
 						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>japicmp</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.siom79.japicmp</groupId>
+						<artifactId>japicmp-maven-plugin</artifactId>
+						<version>${project.version}</version>
+						<configuration>
+							<newVersion>
+								<file>
+									<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+								</file>
+							</newVersion>
+							<parameter>
+								<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
+								<onlyModified>true</onlyModified>
+							</parameter>
+							<skip>false</skip>
+						</configuration>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>cmp</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -113,6 +113,31 @@
 					</argLine>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>${project.version}</version>
+				<configuration>
+					<newVersion>
+						<file>
+							<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+						</file>
+					</newVersion>
+					<parameter>
+						<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
+						<onlyModified>true</onlyModified>
+					</parameter>
+					<skip>false</skip>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/japicmp/pom.xml
+++ b/japicmp/pom.xml
@@ -113,6 +113,31 @@
 					</argLine>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>0.23.0</version> <!-- hard code old version due to cyclic dependencies -->
+				<executions>
+					<execution>
+						<id>github-job-summary</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>cmp</goal>
+						</goals>
+						<configuration>
+							<newVersion>
+								<file>
+									<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+								</file>
+							</newVersion>
+							<parameter>
+								<oldVersionPattern>\d+\.\d+\.\d+</oldVersionPattern>
+								<onlyModified>true</onlyModified>
+							</parameter>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -451,13 +451,6 @@
 							<source>8</source>
 						</configuration>
 					</plugin>
-					<plugin>
-						<groupId>com.github.spotbugs</groupId>
-						<artifactId>spotbugs-maven-plugin</artifactId>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,13 @@
 							<source>8</source>
 						</configuration>
 					</plugin>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>4.7.2.0</version>
+					<version>4.8.6.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR adds the new markdown summary report to the github summary.

The version of the `japicmp-maven-plugin` is hard coded due to cyclic dependencies plugin (we try to generate a report with the current version that is build). Using an additional site-report step did not succeed, because the spotbugs plugin no longer supports in the current version java 1.8 (and the build fails). Skipping the spotbugs plugin in the site-report only for JDK 1.8 did not work.