### PR TITLE
Refactor some usages of `Optional`

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpMojo.java
@@ -894,7 +894,7 @@ public class JApiCmpMojo extends AbstractMojo {
 	private String guessVersion(File file) {
 		String name = file.getName();
 		Optional<SemanticVersion> semanticVersion = japicmp.versioning.Version.getSemanticVersion(name);
-		String version = semanticVersion.isPresent() ? semanticVersion.get().toString() : "n.a.";
+		String version = semanticVersion.map(Object::toString).orElse("n.a.");
 		if (name.contains("SNAPSHOT")) {
 			version += "-SNAPSHOT";
 		}

--- a/japicmp/src/main/java/japicmp/cmp/JarArchiveComparatorOptions.java
+++ b/japicmp/src/main/java/japicmp/cmp/JarArchiveComparatorOptions.java
@@ -10,7 +10,7 @@ import japicmp.model.JApiSemanticVersionLevel;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -103,10 +103,8 @@ public class JarArchiveComparatorOptions {
 	}
 
 	private static void toJarArchiveComparatorClassPath(Optional<String> classPathOptional, List<String> comparatorClassPath) {
-		if (classPathOptional.isPresent()) {
-			String classPathAsString = classPathOptional.get();
-			Collections.addAll(comparatorClassPath, classPathAsString.split(File.pathSeparator));
-		}
+		classPathOptional.map(classPathAsString -> Arrays.asList(classPathAsString.split(File.pathSeparator)))
+			.ifPresent(comparatorClassPath::addAll);
 	}
 
 	public Filters getFilters() {

--- a/japicmp/src/main/java/japicmp/model/AccessModifier.java
+++ b/japicmp/src/main/java/japicmp/model/AccessModifier.java
@@ -34,10 +34,9 @@ public enum AccessModifier implements JApiModifierBase {
 	}
 
 	public static Optional<AccessModifier> toModifier(String accessModifierArg) {
-		Optional<String> stringOptional = Optional.ofNullable(accessModifierArg);
-		if (stringOptional.isPresent()) {
+		if (accessModifierArg != null) {
 			try {
-				return Optional.of(valueOf(stringOptional.get().toUpperCase()));
+				return Optional.of(valueOf(accessModifierArg.toUpperCase()));
 			} catch (IllegalArgumentException e) {
 				throw new JApiCmpException(JApiCmpException.Reason.CliError, String.format("Invalid value for option accessModifier: %s. Possible values are: %s.",
 					accessModifierArg, listOfAccessModifier()), e);

--- a/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAnnotation.java
@@ -97,11 +97,7 @@ public class JApiAnnotation implements JApiHasChangeStatus, JApiCompatibility {
 		if (memberNames != null) {
 			for (String memberName : memberNames) {
 				MemberValue memberValue = annotation.getMemberValue(memberName);
-				if (memberValue == null) {
-					map.put(memberName, Optional.<MemberValue>empty());
-				} else {
-					map.put(memberName, Optional.of(memberValue));
-				}
+				map.put(memberName, Optional.ofNullable(memberValue));
 			}
 		}
 		return map;

--- a/japicmp/src/main/java/japicmp/model/JApiAnnotationElement.java
+++ b/japicmp/src/main/java/japicmp/model/JApiAnnotationElement.java
@@ -103,6 +103,14 @@ public class JApiAnnotationElement implements JApiHasChangeStatus, JApiCompatibi
 		}
 	}
 
+	private static List<JApiAnnotationElementValue> getElementValues(MemberValue memberValue) {
+		JApiAnnotationElementValue elementValue = getMemberValue(memberValue);
+		if(elementValue.getType() == JApiAnnotationElementValue.Type.Array) {
+			return new ArrayList<>(elementValue.getValues());
+		}
+		return new ArrayList<>(Collections.singleton(elementValue));
+	}
+
 	@XmlAttribute(name = "name")
 	public String getName() {
 		return name;
@@ -127,31 +135,13 @@ public class JApiAnnotationElement implements JApiHasChangeStatus, JApiCompatibi
 	@XmlElementWrapper(name = "oldElementValues")
 	@XmlElement(name = "oldElementValue")
 	public List<JApiAnnotationElementValue> getOldElementValues() {
-		List<JApiAnnotationElementValue> values = new ArrayList<>();
-		if (this.oldValue.isPresent()) {
-			JApiAnnotationElementValue memberValue = getMemberValue(this.oldValue.get());
-			if (memberValue.getType() == JApiAnnotationElementValue.Type.Array) {
-				values.addAll(memberValue.getValues());
-			} else {
-				values.add(memberValue);
-			}
-		}
-		return values;
+		return this.oldValue.map(JApiAnnotationElement::getElementValues).orElseGet(ArrayList::new);
 	}
 
 	@XmlElementWrapper(name = "newElementValues")
 	@XmlElement(name = "newElementValue")
 	public List<JApiAnnotationElementValue> getNewElementValues() {
-		List<JApiAnnotationElementValue> values = new ArrayList<>();
-		if (this.newValue.isPresent()) {
-			JApiAnnotationElementValue memberValue = getMemberValue(this.newValue.get());
-			if (memberValue.getType() == JApiAnnotationElementValue.Type.Array) {
-				values.addAll(memberValue.getValues());
-			} else {
-				values.add(memberValue);
-			}
-		}
-		return values;
+		return this.newValue.map(JApiAnnotationElement::getElementValues).orElseGet(ArrayList::new);
 	}
 
 	@XmlAttribute

--- a/japicmp/src/main/java/japicmp/model/JApiField.java
+++ b/japicmp/src/main/java/japicmp/model/JApiField.java
@@ -267,14 +267,8 @@ public class JApiField implements JApiHasChangeStatus, JApiHasModifiers, JApiHas
 
 	@XmlAttribute(name = "name")
 	public String getName() {
-		String name = "n.a.";
-		if (oldFieldOptional.isPresent()) {
-			name = oldFieldOptional.get().getName();
-		}
-		if (newFieldOptional.isPresent()) {
-			name = newFieldOptional.get().getName();
-		}
-		return name;
+		return oldFieldOptional.map(CtField::getName)
+			.orElseGet(() -> newFieldOptional.map(CtField::getName).orElse("n.a."));
 	}
 
 	@XmlTransient

--- a/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
+++ b/japicmp/src/main/java/japicmp/model/JApiImplementedInterface.java
@@ -36,35 +36,15 @@ public class JApiImplementedInterface implements JApiHasChangeStatus, JApiCompat
 	@Override
 	@XmlAttribute
 	public boolean isBinaryCompatible() {
-		boolean binaryCompatible = true;
-		for (JApiCompatibilityChange compatibilityChange : compatibilityChanges) {
-			if (!compatibilityChange.isBinaryCompatible()) {
-				binaryCompatible = false;
-			}
-		}
-		if (binaryCompatible && correspondingJApiClass.isPresent()) {
-			if (!correspondingJApiClass.get().isBinaryCompatible()) {
-				binaryCompatible = false;
-			}
-		}
-		return binaryCompatible;
+		return compatibilityChanges.stream().allMatch(JApiCompatibilityChange::isBinaryCompatible)
+			&& correspondingJApiClass.map(JApiClass::isBinaryCompatible).orElse(true);
 	}
 
 	@Override
 	@XmlAttribute
 	public boolean isSourceCompatible() {
-		boolean sourceCompatible = true;
-		for (JApiCompatibilityChange compatibilityChange : compatibilityChanges) {
-			if (!compatibilityChange.isSourceCompatible()) {
-				sourceCompatible = false;
-			}
-		}
-		if (sourceCompatible && correspondingJApiClass.isPresent()) {
-			if (!correspondingJApiClass.get().isSourceCompatible()) {
-				sourceCompatible = false;
-			}
-		}
-		return sourceCompatible;
+		return compatibilityChanges.stream().allMatch(JApiCompatibilityChange::isSourceCompatible)
+			&& correspondingJApiClass.map(JApiClass::isSourceCompatible).orElse(true);
 	}
 
 	@XmlElementWrapper(name = "compatibilityChanges")

--- a/japicmp/src/main/java/japicmp/model/JApiMethod.java
+++ b/japicmp/src/main/java/japicmp/model/JApiMethod.java
@@ -80,52 +80,26 @@ public class JApiMethod extends JApiBehavior {
 	}
 
 	public boolean hasSameReturnType(JApiMethod otherMethod) {
-		boolean haveSameReturnType = false;
 		JApiReturnType otherReturnType = otherMethod.getReturnType();
 		if (otherReturnType.getChangeStatus() == JApiChangeStatus.UNCHANGED || otherReturnType.getChangeStatus() == JApiChangeStatus.MODIFIED) {
 			if (this.returnType.getChangeStatus() == JApiChangeStatus.UNCHANGED || this.returnType.getChangeStatus() == JApiChangeStatus.MODIFIED) {
-				if (otherReturnType.getOldReturnType().equals(this.returnType.getOldReturnType()) && otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
+				return otherReturnType.getOldReturnType().equals(this.returnType.getOldReturnType())
+					&& otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType());
 			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.NEW) {
-				if (otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
-			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.REMOVED) {
-				if (otherReturnType.getOldReturnType().equals(this.returnType.getOldReturnType())) {
-					haveSameReturnType = true;
-				}
+				return otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType());
 			}
-		} else if (otherReturnType.getChangeStatus() == JApiChangeStatus.NEW) {
-			if (this.returnType.getChangeStatus() == JApiChangeStatus.UNCHANGED || this.returnType.getChangeStatus() == JApiChangeStatus.MODIFIED) {
-				if (otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
-			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.NEW) {
-				if (otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
-			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.REMOVED) {
-				if (otherReturnType.getNewReturnType().equals(this.returnType.getOldReturnType())) {
-					haveSameReturnType = true;
-				}
-			}
-		} else {
-			if (this.returnType.getChangeStatus() == JApiChangeStatus.UNCHANGED || this.returnType.getChangeStatus() == JApiChangeStatus.MODIFIED) {
-				if (otherReturnType.getOldReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
-			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.NEW) {
-				if (otherReturnType.getOldReturnType().equals(this.returnType.getNewReturnType())) {
-					haveSameReturnType = true;
-				}
-			} else if (this.returnType.getChangeStatus() == JApiChangeStatus.REMOVED) {
-				if (otherReturnType.getOldReturnType().equals(this.returnType.getOldReturnType())) {
-					haveSameReturnType = true;
-				}
-			}
+			return otherReturnType.getOldReturnType().equals(returnType.getOldReturnType());
 		}
-		return haveSameReturnType;
+		if (otherReturnType.getChangeStatus() == JApiChangeStatus.NEW) {
+			if (this.returnType.getChangeStatus() == JApiChangeStatus.REMOVED) {
+				return otherReturnType.getNewReturnType().equals(this.returnType.getOldReturnType());
+			}
+			return otherReturnType.getNewReturnType().equals(this.returnType.getNewReturnType());
+		}
+		if (returnType.getChangeStatus() == JApiChangeStatus.REMOVED) {
+			return otherReturnType.getOldReturnType().equals(this.returnType.getOldReturnType());
+		}
+		return otherReturnType.getOldReturnType().equals(this.returnType.getNewReturnType());
 	}
 
 	public boolean hasSameSignature(JApiMethod jApiMethod) {
@@ -161,13 +135,7 @@ public class JApiMethod extends JApiBehavior {
 	}
 
 	public static String toString(Optional<CtMethod> method) {
-		if(method == null ) {
-			return OptionalHelper.N_A;
-		}
-		if(method.isPresent()) {
-			return method.get().getLongName();
-		}
-		return OptionalHelper.N_A;
+		return method.map(CtMethod::getLongName).orElse(OptionalHelper.N_A);
 	}
 
 	@Override

--- a/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiSuperclass.java
@@ -77,12 +77,12 @@ public class JApiSuperclass implements JApiHasChangeStatus, JApiCompatibility {
 
 	@XmlTransient
 	public Optional<String> getOldSuperclassName() {
-		return oldSuperclassOptional.isPresent() ? Optional.of(oldSuperclassOptional.get().getName()) : Optional.<String>empty();
+		return oldSuperclassOptional.map(CtClass::getName);
 	}
 
 	@XmlTransient
 	public Optional<String> getNewSuperclassName() {
-		return newSuperclassOptional.isPresent() ? Optional.of(newSuperclassOptional.get().getName()) : Optional.<String>empty();
+		return newSuperclassOptional.map(CtClass::getName);
 	}
 
 	@XmlAttribute(name = "changeStatus")
@@ -149,21 +149,12 @@ public class JApiSuperclass implements JApiHasChangeStatus, JApiCompatibility {
 
 	public String toString()
 	{
-		String oldSuperClass = "n.a.";
-		if(oldSuperclassOptional.isPresent()) {
-			oldSuperClass = oldSuperclassOptional.get().getName();
-		}
-		String newSuperClass = "n.a.";
-		if(newSuperclassOptional.isPresent()) {
-			newSuperClass = newSuperclassOptional.get().getName();
-		}
-
 		return "JApiSuperclass [jApiClass="
 			+ jApiClass
 			+ ", oldSuperclass="
-			+ oldSuperClass
+			+ oldSuperclassOptional.map(CtClass::getName).orElse("n.a.")
 			+ ", newSuperclass="
-			+ newSuperClass
+			+ newSuperclassOptional.map(CtClass::getName).orElse("n.a.")
 			+ ", changeStatus="
 			+ changeStatus
 			+ ", compatibilityChanges="

--- a/japicmp/src/main/java/japicmp/model/JApiType.java
+++ b/japicmp/src/main/java/japicmp/model/JApiType.java
@@ -44,12 +44,9 @@ public class JApiType implements JApiHasChangeStatus {
 	}
 
 	public boolean hasChanged() {
-		boolean hasChanged = false;
 		if (oldTypeOptional.isPresent() && newTypeOptional.isPresent()) {
-			if (!oldTypeOptional.get().equals(newTypeOptional.get())) {
-				hasChanged = true;
-			}
+			return !oldTypeOptional.equals(newTypeOptional);
 		}
-		return hasChanged;
+		return false;
 	}
 }

--- a/japicmp/src/main/java/japicmp/output/html/HtmlOutputGenerator.java
+++ b/japicmp/src/main/java/japicmp/output/html/HtmlOutputGenerator.java
@@ -643,9 +643,6 @@ public class HtmlOutputGenerator extends OutputGenerator<HtmlOutput> {
 	}
 
 	private String getTitle() {
-		if (this.htmlOutputGeneratorOptions.getTitle().isPresent()) {
-			return this.htmlOutputGeneratorOptions.getTitle().get();
-		}
-		return "japicmp-Report";
+		return this.htmlOutputGeneratorOptions.getTitle().orElse("japicmp-Report");
 	}
 }

--- a/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
+++ b/japicmp/src/main/java/japicmp/output/incompatible/IncompatibleErrorOutput.java
@@ -89,15 +89,11 @@ public class IncompatibleErrorOutput extends OutputGenerator<Void> {
 			List<SemanticVersion> newVersions = new ArrayList<>();
 			for (JApiCmpArchive file : options.getOldArchives()) {
 				Optional<SemanticVersion> semanticVersion = file.getVersion().getSemanticVersion();
-				if (semanticVersion.isPresent()) {
-					oldVersions.add(semanticVersion.get());
-				}
+				semanticVersion.ifPresent(oldVersions::add);
 			}
 			for (JApiCmpArchive file : options.getNewArchives()) {
 				Optional<SemanticVersion> semanticVersion = file.getVersion().getSemanticVersion();
-				if (semanticVersion.isPresent()) {
-					newVersions.add(semanticVersion.get());
-				}
+				semanticVersion.ifPresent(newVersions::add);
 			}
 			VersionChange versionChange = new VersionChange(oldVersions, newVersions, ignoreMissingOldVersion, ignoreMissingNewVersion);
 			if (!versionChange.isAllMajorVersionsZero() || options.isErrorOnSemanticIncompatibilityForMajorVersionZero()) {

--- a/japicmp/src/main/java/japicmp/output/markdown/MarkdownOutputGenerator.java
+++ b/japicmp/src/main/java/japicmp/output/markdown/MarkdownOutputGenerator.java
@@ -289,7 +289,7 @@ public class MarkdownOutputGenerator extends OutputGenerator<String> {
 
 	private String renderClassType(JApiClass clazz) {
 		final JApiClassType classType = clazz.getClassType();
-		return renderChange(classType, md.message.getClassType(classType.getOldTypeOptional()), md.message.getClassType(classType.getNewTypeOptional()));
+		return renderChange(classType, classType.getOldTypeOptional().map(md.message::getClassType).orElse(EMPTY), classType.getNewTypeOptional().map(md.message::getClassType).orElse(EMPTY));
 	}
 
 	private String renderClassSuperclass(JApiClass clazz) {
@@ -512,12 +512,8 @@ public class MarkdownOutputGenerator extends OutputGenerator<String> {
 	}
 
 	private String renderMemberValue(Optional<MemberValue> optionalValue) {
-		if (!optionalValue.isPresent()) {
-			return EMPTY;
-		}
-		final String fullValue = formatMemberValue(optionalValue.get(), false);
-		final String simpleValue = formatMemberValue(optionalValue.get(), true);
-		return renderCodeWithTooltip(fullValue, simpleValue);
+		return optionalValue.map(x -> renderCodeWithTooltip(formatMemberValue(x, false), formatMemberValue(x, true)))
+			.orElse(EMPTY);
 	}
 
 	private String renderReturnType(JApiMethod method) {

--- a/japicmp/src/main/java/japicmp/output/markdown/config/MarkdownMessageOptions.java
+++ b/japicmp/src/main/java/japicmp/output/markdown/config/MarkdownMessageOptions.java
@@ -12,7 +12,6 @@ import japicmp.output.markdown.MarkdownBadge;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.Optional;
 
 public class MarkdownMessageOptions {
 
@@ -151,11 +150,8 @@ public class MarkdownMessageOptions {
 		}
 	}
 
-	public String getClassType(Optional<JApiClassType.ClassType> classType) {
-		if (!classType.isPresent()) {
-			return EMPTY;
-		}
-		switch (classType.get()) {
+	public String getClassType(JApiClassType.ClassType classType) {
+		switch (classType) {
 			case ANNOTATION:
 				return typeAnnotation;
 			case INTERFACE:

--- a/japicmp/src/main/java/japicmp/output/xml/model/JApiCmpXmlRoot.java
+++ b/japicmp/src/main/java/japicmp/output/xml/model/JApiCmpXmlRoot.java
@@ -120,13 +120,7 @@ public class JApiCmpXmlRoot {
 
 	@XmlAttribute
 	public String getTitle() {
-		String title;
-		if (this.titleOptional.isPresent()) {
-			title = this.titleOptional.get();
-		} else {
-			title = "JApiCmp-Report";
-		}
-		return title;
+		return this.titleOptional.orElse("JApiCmp-Report");
 	}
 
 	public void setTitle(String title) {

--- a/japicmp/src/main/java/japicmp/util/ModifierHelper.java
+++ b/japicmp/src/main/java/japicmp/util/ModifierHelper.java
@@ -68,20 +68,12 @@ public class ModifierHelper {
 
 	public static boolean isNotPrivate(JApiHasAccessModifier jApiHasAccessModifier) {
 		JApiModifier<AccessModifier> accessModifier = jApiHasAccessModifier.getAccessModifier();
-		if (accessModifier.getOldModifier().isPresent() && accessModifier.getNewModifier().isPresent()) {
-			if (accessModifier.getNewModifier().get().getLevel() > AccessModifier.PRIVATE.getLevel() || accessModifier.getOldModifier().get().getLevel() > AccessModifier.PRIVATE.getLevel()) {
-				return true;
-			}
-		} else if (!accessModifier.getOldModifier().isPresent() && accessModifier.getNewModifier().isPresent()) {
-			if (accessModifier.getNewModifier().get().getLevel() > AccessModifier.PRIVATE.getLevel()) {
-				return true;
-			}
-		} else if (accessModifier.getOldModifier().isPresent() && !accessModifier.getNewModifier().isPresent()) {
-			if (accessModifier.getOldModifier().get().getLevel() > AccessModifier.PRIVATE.getLevel()) {
-				return true;
-			}
-		}
-		return false;
+		return accessModifier.getOldModifier().map(ModifierHelper::isNotPrivate).orElse(false)
+			|| accessModifier.getNewModifier().map(ModifierHelper::isNotPrivate).orElse(false);
+	}
+
+	private static boolean isNotPrivate(AccessModifier accessModifier) {
+		return accessModifier != AccessModifier.PRIVATE;
 	}
 
 	public static boolean hasModifierLevelDecreased(JApiHasAccessModifier hasAccessModifier) {
@@ -246,51 +238,26 @@ public class ModifierHelper {
 	}
 
 	private static Optional<String> getModifierName(Optional<? extends Enum<?>> modifier) {
-		return !modifier.isPresent() || IGNORED_MODIFIERS.contains(modifier.get()) ? Optional.empty() :
-			Optional.of(modifier.get().name().toLowerCase());
+		return modifier.filter(x -> !IGNORED_MODIFIERS.contains(x))
+			.map(Enum::name)
+			.map(String::toLowerCase);
 	}
 
 	private static boolean hasSyntheticAttribute(JApiAttribute<SyntheticAttribute> syntheticAttribute) {
-		boolean hasSyntheticAttribute = false;
+		final boolean oldIsSynthetic = syntheticAttribute.getOldAttribute().map(SyntheticAttribute.SYNTHETIC::equals).orElse(false);
+		final boolean newIsSynthetic = syntheticAttribute.getNewAttribute().map(SyntheticAttribute.SYNTHETIC::equals).orElse(false);
 		if (syntheticAttribute.getOldAttribute().isPresent() && syntheticAttribute.getNewAttribute().isPresent()) {
-			SyntheticAttribute oldAttribute = syntheticAttribute.getOldAttribute().get();
-			SyntheticAttribute newAttribute = syntheticAttribute.getNewAttribute().get();
-			if (oldAttribute == SyntheticAttribute.SYNTHETIC && newAttribute == SyntheticAttribute.SYNTHETIC) {
-				hasSyntheticAttribute = true;
-			}
-		} else if (syntheticAttribute.getOldAttribute().isPresent()) {
-			SyntheticAttribute oldAttribute = syntheticAttribute.getOldAttribute().get();
-			if (oldAttribute == SyntheticAttribute.SYNTHETIC) {
-				hasSyntheticAttribute = true;
-			}
-		} else if (syntheticAttribute.getNewAttribute().isPresent()) {
-			SyntheticAttribute newAttribute = syntheticAttribute.getNewAttribute().get();
-			if (newAttribute == SyntheticAttribute.SYNTHETIC) {
-				hasSyntheticAttribute = true;
-			}
+			return oldIsSynthetic && newIsSynthetic;
 		}
-		return hasSyntheticAttribute;
+		return oldIsSynthetic || newIsSynthetic;
 	}
 
 	private static boolean hasSyntheticModifier(JApiModifier<SyntheticModifier> syntheticModifier) {
-		boolean hasSyntheticModifier = false;
+		final boolean oldIsSynthetic = syntheticModifier.getOldModifier().map(SyntheticModifier.SYNTHETIC::equals).orElse(false);
+		final boolean newIsSynthetic = syntheticModifier.getNewModifier().map(SyntheticModifier.SYNTHETIC::equals).orElse(false);
 		if (syntheticModifier.getOldModifier().isPresent() && syntheticModifier.getNewModifier().isPresent()) {
-			SyntheticModifier oldModifier = syntheticModifier.getOldModifier().get();
-			SyntheticModifier newModifier = syntheticModifier.getNewModifier().get();
-			if (oldModifier == SyntheticModifier.SYNTHETIC && newModifier == SyntheticModifier.SYNTHETIC) {
-				hasSyntheticModifier = true;
-			}
-		} else if (syntheticModifier.getOldModifier().isPresent()) {
-			SyntheticModifier oldModifier = syntheticModifier.getOldModifier().get();
-			if (oldModifier == SyntheticModifier.SYNTHETIC) {
-				hasSyntheticModifier = true;
-			}
-		} else if (syntheticModifier.getNewModifier().isPresent()) {
-			SyntheticModifier newModifier = syntheticModifier.getNewModifier().get();
-			if (newModifier == SyntheticModifier.SYNTHETIC) {
-				hasSyntheticModifier = true;
-			}
+			return oldIsSynthetic && newIsSynthetic;
 		}
-		return hasSyntheticModifier;
+		return oldIsSynthetic || newIsSynthetic;
 	}
 }

--- a/japicmp/src/main/java/japicmp/util/OptionalHelper.java
+++ b/japicmp/src/main/java/japicmp/util/OptionalHelper.java
@@ -10,9 +10,6 @@ public class OptionalHelper {
 	}
 
 	public static <T> String optionalToString(Optional<T> optional) {
-		if (optional.isPresent()) {
-			return optional.get().toString();
-		}
-		return N_A;
+		return optional.map(Object::toString).orElse(N_A);
 	}
 }

--- a/japicmp/src/main/java/japicmp/versioning/VersionChange.java
+++ b/japicmp/src/main/java/japicmp/versioning/VersionChange.java
@@ -49,10 +49,7 @@ public class VersionChange {
 				for (int i=0; i<oldVersions.size(); i++) {
 					SemanticVersion oldVersion = oldVersions.get(i);
 					SemanticVersion newVersion = newVersions.get(i);
-					Optional<SemanticVersion.ChangeType> changeTypeOptional = oldVersion.computeChangeType(newVersion);
-					if (changeTypeOptional.isPresent()) {
-						changeTypes.add(changeTypeOptional.get());
-					}
+					oldVersion.computeChangeType(newVersion).ifPresent(changeTypes::add);
 				}
 				SemanticVersion.ChangeType maxRank = SemanticVersion.ChangeType.UNCHANGED;
 				for (SemanticVersion.ChangeType changeType : changeTypes) {


### PR DESCRIPTION
Now that [Optional instances are unified](https://github.com/siom79/japicmp/pull/407), we can refactor some usages to simplify and hopefully make the codebase easier to understand and maintain.

###### Examples

<table>
<tr>
<th>Before refactor</th>
<th>After refactor</th>
</tr>
<tr>
<td markdown="1">

```java
if (OPTIONAL.isPresent()) {
    return OPTIONAL.get().toString();
}
return "OTHER";
```
</td>
<td markdown="1">

```java
return OPTIONAL.map(Object::toString).orElse("OTHER");
```
</td>
</tr>
<tr>
<td markdown="1">

```java
if (OPTIONAL.isPresent()) {
   x.DO_SOMETHING(OPTIONAL.get());
}
```
</td>
<td markdown="1">

```java
OPTIONAL.ifPresent(x::DO_SOMETHING);
```
</td>
</tr>
</table>

> [!NOTE]
> Merging this PR should not add new features or alter existing functionality in any way. The main goal is to avoid both conditional branching and unwrapping optionals if the code is more readable without it. This results in a more idiomatic usage of `Optional` and reduces cyclomatic complexity.

@siom79 Please let me know your thoughts about this refactor. I understand readability may be subjective; there's no need to merge any of these changes if you are uncomfortable or unsure about them.
