### PR TITLE
Remove unused code in FileHelper and JApiCmpArchive

### DIFF
--- a/japicmp/src/main/java/japicmp/cmp/JApiCmpArchive.java
+++ b/japicmp/src/main/java/japicmp/cmp/JApiCmpArchive.java
@@ -6,20 +6,12 @@ import java.io.File;
 
 public class JApiCmpArchive {
 	private File file;
-	private byte[] bytes;
 	private final Version version;
-	private String name;
 
 	public JApiCmpArchive(File file, String version) {
 		this.file = file;
 		this.version = new Version(version);
 	}
-
-	public JApiCmpArchive(byte[] bytes, String version, String name) {
-		this.bytes = bytes;
-		this.version = new Version(version);
-        this.name = name;
-    }
 
 	public File getFile() {
 		return file;
@@ -29,28 +21,11 @@ public class JApiCmpArchive {
 		return version;
 	}
 
-	public byte[] getBytes() {
-		return bytes;
-	}
-
-	public String getName() {
-		return name;
-	}
-
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("JApiCmpArchive{");
 		sb.append("file=").append(file);
-		sb.append(", bytes=");
-		if (bytes == null) sb.append("null");
-		else {
-			sb.append('[');
-			for (int i = 0; i < bytes.length; ++i)
-				sb.append(i == 0 ? "" : ", ").append(bytes[i]);
-			sb.append(']');
-		}
 		sb.append(", version=").append(version);
-		sb.append(", name='").append(name).append('\'');
 		sb.append('}');
 		return sb.toString();
 	}

--- a/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
+++ b/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
@@ -20,7 +20,6 @@ import java.io.*;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -228,39 +227,9 @@ public class JarArchiveComparator {
 			} catch (IOException e) {
 				throw new JApiCmpException(Reason.IoException, "Failed to load archive from file: " + e.getMessage(), e);
 			}
-		} else if (archive.getBytes() != null) {
-			return bytesToCtClasses(archive, classPool);
 		} else {
-			throw new JApiCmpException(Reason.IllegalArgument, JApiCmpArchive.class.getSimpleName() + " has no file and no bytes: " + archive);
+			throw new JApiCmpException(Reason.IllegalArgument, JApiCmpArchive.class.getSimpleName() + " has no file: " + archive);
 		}
-	}
-
-	private static Stream<CtClass> bytesToCtClasses(JApiCmpArchive archive, ReducibleClassPool classPool) {
-		List<CtClass> ctClasses = new ArrayList<>();
-		try (JarInputStream jarInputStream = new JarInputStream(new ByteArrayInputStream(archive.getBytes()))) {
-			JarEntry nextJarEntry = jarInputStream.getNextJarEntry();
-			while (nextJarEntry != null) {
-				if (!nextJarEntry.isDirectory() && nextJarEntry.getName().endsWith(".class")) {
-					byte[] byteArray = getJarEntryContent(jarInputStream);
-					CtClass ctClass = classPool.makeClass(new ByteArrayInputStream(byteArray));
-					ctClasses.add(ctClass);
-				}
-				nextJarEntry = jarInputStream.getNextJarEntry();
-			}
-		} catch (IOException e) {
-			throw new JApiCmpException(Reason.IoException, "Failed to load archive from byte array: " + e.getMessage(), e);
-		}
-		return ctClasses.stream();
-	}
-
-	private static byte[] getJarEntryContent(JarInputStream jarInputStream) throws IOException {
-		int len;
-		byte[] buffer = new byte[1024];
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		while ((len = jarInputStream.read(buffer)) > 0) {
-			baos.write(buffer, 0, len);
-		}
-        return baos.toByteArray();
 	}
 
 	private CtClass ctClass(ClassPool classPool, JarFile jarFile, JarEntry jarEntry) {

--- a/japicmp/src/main/java/japicmp/config/Options.java
+++ b/japicmp/src/main/java/japicmp/config/Options.java
@@ -332,17 +332,9 @@ public class Options {
 		List<String> paths = new ArrayList<>(archives.size());
 		for (JApiCmpArchive archive : archives) {
 			if (this.reportOnlyFilename) {
-				if (archive.getFile() != null) {
-					paths.add(archive.getFile().getName());
-				} else {
-					paths.add(archive.getName());
-				}
+				paths.add(archive.getFile().getName());
 			} else {
-				if (archive.getFile() != null) {
-					paths.add(archive.getFile().getAbsolutePath());
-				} else {
-					paths.add(archive.getName());
-				}
+				paths.add(archive.getFile().getAbsolutePath());
 			}
 		}
 		return paths;

--- a/japicmp/src/main/java/japicmp/util/FileHelper.java
+++ b/japicmp/src/main/java/japicmp/util/FileHelper.java
@@ -12,22 +12,6 @@ public class FileHelper {
 		// intentionally left empty
 	}
 
-	public static List<File> toFileList(List<JApiCmpArchive> archives) {
-		List<File> files = new ArrayList<>(archives.size());
-		for (JApiCmpArchive archive : archives) {
-			files.add(archive.getFile());
-		}
-		return files;
-	}
-
-	public static List<String> toVersionList(List<JApiCmpArchive> archives) {
-		List<String> versions = new ArrayList<>(archives.size());
-		for (JApiCmpArchive archive : archives) {
-			versions.add(archive.getVersion().getStringVersion());
-		}
-		return versions;
-	}
-
 	public static List<JApiCmpArchive> createFileList(String option) {
 		String[] parts = option.split(";");
 		List<JApiCmpArchive> jApiCmpArchives = new ArrayList<>(parts.length);


### PR DESCRIPTION
I don't know if the modifications below to japicmp itself break an API guarantee of japicmp. If not, I offer this PR to clean these unused items while working on https://github.com/siom79/japicmp/pull/467. If they need to be kept around, then please close this PR.

These removed methods/constructors are unused in both src and tests.

FileHelper.toFileList and toVersionList are unused in japicmp.

JApiCmpArchive(byte[], String, String) constructor is unused, and all cases of the other constructor pass a non-null File, therefore the getBytes/getName code paths are unreachable and all calls to them can be removed too.

