### PR TITLE
Fix default values for Maven configuration parameters

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/ConfigParameters.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/ConfigParameters.java
@@ -49,7 +49,7 @@ public class ConfigParameters {
 	private List<String> ignoreMissingClassesByRegularExpressions;
 
 	@Parameter(defaultValue = "true")
-	private boolean skipPomModules;
+	private boolean skipPomModules = true;
 
 	@Parameter
 	private String htmlStylesheet;
@@ -85,7 +85,7 @@ public class ConfigParameters {
 	private boolean skipXmlReport;
 
 	@Parameter(defaultValue = "true")
-	private boolean ignoreMissingOldVersion;
+	private boolean ignoreMissingOldVersion = true;
 
 	@Parameter
 	private boolean ignoreMissingNewVersion;
@@ -94,10 +94,10 @@ public class ConfigParameters {
 	private String oldVersionPattern;
 
 	@Parameter(defaultValue = "false")
-	private boolean includeSnapshots;
+	private boolean includeSnapshots = false;
 
 	@Parameter(defaultValue = "true")
-	private boolean breakBuildIfCausedByExclusion;
+	private boolean breakBuildIfCausedByExclusion = true;
 
 	@Parameter
 	private boolean reportOnlyFilename;
@@ -113,10 +113,10 @@ public class ConfigParameters {
 
 
 	@Parameter(defaultValue = "false")
-	private boolean includeExclusively;
+	private boolean includeExclusively = false;
 
 	@Parameter(defaultValue = "false")
-	private boolean excludeExclusively;
+	private boolean excludeExclusively = false;
 
 	@Parameter
 	private List<OverrideCompatibilityChangeParameter> overrideCompatibilityChangeParameters;

--- a/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
+++ b/japicmp-maven-plugin/src/test/java/japicmp/maven/JApiCmpMojoTest.java
@@ -1,5 +1,7 @@
 package japicmp.maven;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -31,6 +33,21 @@ final class JApiCmpMojoTest extends AbstractTest {
 	 */
 	JApiCmpMojoTest() {
 		super();
+	}
+
+	@Test
+	@InjectMojo(goal = "cmp", pom = "target/test-run/default/pom.xml")
+	void testDefaultParameterValues(final JApiCmpMojo testMojo) {
+		assertNotNull(testMojo);
+		assertNotNull(testMojo.parameter);
+
+		// Verify all default values are set correctly
+		assertThat(testMojo.parameter.getSkipPomModules(), is(true));
+		assertThat(testMojo.parameter.getIgnoreMissingOldVersion(), is(true));
+		assertThat(testMojo.parameter.isIncludeSnapshots(), is(false));
+		assertThat(testMojo.parameter.isBreakBuildIfCausedByExclusion(), is(true));
+		assertThat(testMojo.parameter.isIncludeExclusively(), is(false));
+		assertThat(testMojo.parameter.isExcludeExclusively(), is(false));
 	}
 
 	@Test

--- a/japicmp-maven-plugin/src/test/resources/data/configured/pom.xml
+++ b/japicmp-maven-plugin/src/test/resources/data/configured/pom.xml
@@ -39,6 +39,7 @@
 						<markdownTitle>New Markdown Title</markdownTitle>
 						<reportLinkName>API Comparison Report</reportLinkName>
 						<postAnalysisScript>groovy/SamplePostAnalysis.groovy</postAnalysisScript>
+						<ignoreMissingOldVersion>false</ignoreMissingOldVersion>
 					</parameter>
 				</configuration>
 				<executions>


### PR DESCRIPTION
fixes #473

Maven `@Parameter`s don't resolve the `defaultValue` for nested objects. As far as I can tell, the only way to work around this is to set the defaults in the field initialisers.