### PR TITLE
feat: Release-Notes aus ReleaseNotes.md in GitHub-Release einbinden

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -21,6 +21,23 @@ jobs:
             - name: Projekt bauen
               run: mvn -B package
 
+            - name: Projektversion ermitteln
+              run: echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+
+            - name: Release-Notes extrahieren
+              run: |
+                python3 - <<'EOF'
+                import re, os
+                version = os.environ['PROJECT_VERSION']
+                with open('src/site/markdown/ReleaseNotes.md') as f:
+                    content = f.read()
+                pattern = rf'{re.escape(version)} \(\d{{4}}-\d{{2}}-\d{{2}}\)\n-+\n(.*?)(?=\n\d+\.\d+\.\d+ \(|\Z)'
+                match = re.search(pattern, content, re.DOTALL)
+                notes = match.group(1).strip() if match else f'Release {version}'
+                with open('release_notes.md', 'w') as out:
+                    out.write(notes)
+                EOF
+
             - name: Artefakte sammeln
               run: mkdir japicmp/build && cp japicmp/target/japicmp*.jar japicmp/build/
 
@@ -28,5 +45,6 @@ jobs:
               uses: softprops/action-gh-release@v2
               with:
                   files: japicmp/build/*.jar
+                  body_file: release_notes.md
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Der gh-release.yml-Workflow liest nun automatisch den passenden
Abschnitt aus src/site/markdown/ReleaseNotes.md und übergibt ihn
als body_file an softprops/action-gh-release@v2.

https://claude.ai/code/session_01SHjUEyWGAGjxFEMsZgRjus