### PR TITLE
Fix false negative when non-bridge method matches compiler-generated bridge method (issue #507)

### DIFF
--- a/japicmp/src/main/java/japicmp/model/JApiClass.java
+++ b/japicmp/src/main/java/japicmp/model/JApiClass.java
@@ -440,7 +440,14 @@ public class JApiClass implements JApiHasModifiers, JApiHasChangeStatus, JApiHas
 		SignatureParser methodSignatureParser = new SignatureParser();
 		methodSignatureParser.parse(method);
 		List<CtMethod> methodsWithSameParameters = new ArrayList<>();
-		findMatchingMethodsWithSameParameterTypes(candidates, methodSignatureParser, methodsWithSameParameters);
+		boolean methodIsBridge = ModifierHelper.isBridge(method.getModifiers());
+		List<CtMethod> eligibleCandidates = new ArrayList<>();
+		for (CtMethod c : candidates) {
+			if (ModifierHelper.isBridge(c.getModifiers()) == methodIsBridge) {
+				eligibleCandidates.add(c);
+			}
+		}
+		findMatchingMethodsWithSameParameterTypes(eligibleCandidates, methodSignatureParser, methodsWithSameParameters);
 		if (methodsWithSameParameters.size() == 1) {
 			found = Optional.of(methodsWithSameParameters.get(0));
 		} else if (methodsWithSameParameters.size() > 1) {

--- a/japicmp/src/test/java/japicmp/compat/GenericsCompatibilityTest.java
+++ b/japicmp/src/test/java/japicmp/compat/GenericsCompatibilityTest.java
@@ -198,4 +198,61 @@ class GenericsCompatibilityTest {
 			assertThat(jApiMethod.getCompatibilityChanges().size(), is(0));
 		}
 	}
+
+	@Test
+	void testNonBridgeMethodNotMatchedWithBridgeMethod() throws Exception {
+		// Regression test for issue #507: when a class switches from a raw-type
+		// implementation to a parameterized one, the compiler generates a bridge method
+		// with the same erased signature. The old non-bridge method must be detected as
+		// REMOVED (not matched to the new bridge method), triggering METHOD_REMOVED.
+		JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
+		options.setAccessModifier(AccessModifier.PRIVATE);
+		options.setIncludeSynthetic(true);
+		List<JApiClass> jApiClasses = ClassesHelper.compareClasses(options, new ClassesHelper.ClassesGenerator() {
+			@Override
+			public List<CtClass> createOldClasses(ClassPool classPool) throws Exception {
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.AbstractVisitor").addToClassPool(classPool);
+				CtMethodBuilder.create()
+					.publicAccess()
+					.returnType(classPool.get("java.lang.Object"))
+					.name("visit")
+					.parameter(classPool.get("java.lang.Object"))
+					.body("return null;")
+					.addToClass(ctClass);
+				return Collections.singletonList(ctClass);
+			}
+
+			@Override
+			public List<CtClass> createNewClasses(ClassPool classPool) throws Exception {
+				CtClass ctClass = CtClassBuilder.create().name("japicmp.AbstractVisitor").addToClassPool(classPool);
+				CtMethodBuilder.create()
+					.publicAccess()
+					.returnType(classPool.get("java.lang.String"))
+					.name("visit")
+					.parameter(classPool.get("java.lang.Integer"))
+					.body("return null;")
+					.addToClass(ctClass);
+				// Compiler-generated bridge method: same erased signature as the old method
+				CtMethod bridgeMethod = CtMethodBuilder.create()
+					.publicAccess()
+					.returnType(classPool.get("java.lang.Object"))
+					.name("visit")
+					.parameter(classPool.get("java.lang.Object"))
+					.body("return null;")
+					.addToClass(ctClass);
+				bridgeMethod.setModifiers(bridgeMethod.getModifiers()
+					| ModifierHelper.ACC_BRIDGE | ModifierHelper.ACC_SYNTHETIC);
+				return Collections.singletonList(ctClass);
+			}
+		});
+		JApiClass jApiClass = getJApiClass(jApiClasses, "japicmp.AbstractVisitor");
+		JApiMethod removedMethod = jApiClass.getMethods().stream()
+			.filter(m -> m.getChangeStatus() == JApiChangeStatus.REMOVED)
+			.findFirst()
+			.orElse(null);
+		assertThat("Old non-bridge visit(Object) must be detected as REMOVED", removedMethod, is(notNullValue()));
+		assertThat(removedMethod.isBinaryCompatible(), is(false));
+		assertThat(removedMethod.getCompatibilityChanges(),
+			hasItem(new JApiCompatibilityChange(JApiCompatibilityChangeType.METHOD_REMOVED)));
+	}
 }


### PR DESCRIPTION
When a class changes from implementing a generic interface with raw types
to concrete type parameters, the Java compiler generates a bridge method
with the same erased signature as the old raw-type method. JApiCmp was
incorrectly matching the old non-bridge method to this new bridge method,
causing the removal to go undetected.

Fix: in findMatchingMethod(), filter candidates to only those with the
same bridge status as the probe method before comparison. This ensures
non-bridge methods are never matched to bridge methods (and vice versa),
so the old method is correctly reported as REMOVED and METHOD_REMOVED
compatibility change is raised.

https://claude.ai/code/session_016hDBKp7sFAaMQ2BfuSbna7