### PR TITLE
Enhance compatibility description in index.md

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -117,7 +117,7 @@ Features
 * Per default private and package protected classes and class members are not compared. If necessary, the access modifier of the classes and class members to be
   compared can be set to public, protected, package or private.
 * Per default all classes are tracked. If necessary, certain packages, classes, methods or fields can be excluded or explicitly included. Inclusion and exclusion is also possible based on annotations.
-* All changes between all classes/methods/fields are compared. japicmp differentiates between source and binary compatible changes (as described in the [Java Language Specification](http://docs.oracle.com/javase/specs/jls/se7/html/jls-13.html)).
+* All changes between all classes/methods/fields are compared. japicmp differentiates between source and binary compatible changes (as described in the [Java Language Specification](http://docs.oracle.com/javase/specs/jls/se7/html/jls-13.html) and in the [OpenJDK-Wiki](https://wiki.openjdk.org/spaces/csr/pages/32342052/Kinds+of+Compatibility)).
 * All changes between annotations are compared, hence japicmp can be used to track annotation-based APIs like JAXB, JPA, JAX-RS, etc.
 * A maven plugin is available that allows you to compare the current artifact version with some older version from the repository.
 * The option `--semantic-versioning` tells you which part of the version you have to increment in order to follow [semantic versioning](http://semver.org/).


### PR DESCRIPTION
Updated the description of japicmp's compatibility changes to include a reference to the OpenJDK-Wiki.