### PR TITLE
Fix NPE in MarkdownOutputGenerator for byte-based JApiCmpArchive (issue #516)

### DIFF
--- a/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpProcessor.java
+++ b/japicmp-maven-plugin/src/main/java/japicmp/maven/JApiCmpProcessor.java
@@ -683,7 +683,7 @@ public class JApiCmpProcessor {
 
 						for (JApiCmpArchive jApiCmpArchive : jApiCmpArchives) {
 							comparatorOptions.getClassPathEntries().add(
-								jApiCmpArchive.getFile().getAbsolutePath());
+								jApiCmpArchive.getFile().map(File::getAbsolutePath).orElse(""));
 						}
 						comparatorOptions.setClassPathMode(
 							JarArchiveComparatorOptions.ClassPathMode.ONE_COMMON_CLASSPATH);
@@ -700,7 +700,7 @@ public class JApiCmpProcessor {
 							List<JApiCmpArchive> jApiCmpArchives = resolveDependencyToFile(
 								"oldClassPathDependencies", dependency, ConfigurationVersion.OLD);
 							for (JApiCmpArchive archive : jApiCmpArchives) {
-								comparatorOptions.getOldClassPath().add(archive.getFile().getAbsolutePath());
+								comparatorOptions.getOldClassPath().add(archive.getFile().map(File::getAbsolutePath).orElse(""));
 							}
 						}
 					}
@@ -709,7 +709,7 @@ public class JApiCmpProcessor {
 							List<JApiCmpArchive> jApiCmpArchives = resolveDependencyToFile(
 								"newClassPathDependencies", dependency, ConfigurationVersion.NEW);
 							for (JApiCmpArchive archive : jApiCmpArchives) {
-								comparatorOptions.getNewClassPath().add(archive.getFile().getAbsolutePath());
+								comparatorOptions.getNewClassPath().add(archive.getFile().map(File::getAbsolutePath).orElse(""));
 							}
 						}
 					}

--- a/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/src/test/java/japicmp/test/service/JavassistTest.java
+++ b/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/src/test/java/japicmp/test/service/JavassistTest.java
@@ -22,13 +22,13 @@ public class JavassistTest {
 	@Test
 	public void test() throws NotFoundException {
 		ClassPool classPoolOld = new ClassPool();
-		classPoolOld.appendClassPath(getArchive("japicmp-test-service-v1.jar").getFile().getAbsolutePath());
-		classPoolOld.appendClassPath(getArchive("japicmp-test-service-impl-v1.jar").getFile().getAbsolutePath());
+		classPoolOld.appendClassPath(getArchive("japicmp-test-service-v1.jar").getFile().get().getAbsolutePath());
+		classPoolOld.appendClassPath(getArchive("japicmp-test-service-impl-v1.jar").getFile().get().getAbsolutePath());
 		CtClass oldClass = classPoolOld.get(SubclassAddsNewStaticField.class.getName());
 		assertThat(oldClass.getSuperclass().getFields().length, is(1));
 		ClassPool classPoolNew = new ClassPool();
-		classPoolNew.appendClassPath(getArchive("japicmp-test-service-v2.jar").getFile().getAbsolutePath());
-		classPoolNew.appendClassPath(getArchive("japicmp-test-service-impl-v2.jar").getFile().getAbsolutePath());
+		classPoolNew.appendClassPath(getArchive("japicmp-test-service-v2.jar").getFile().get().getAbsolutePath());
+		classPoolNew.appendClassPath(getArchive("japicmp-test-service-impl-v2.jar").getFile().get().getAbsolutePath());
 		CtClass newClass = classPoolNew.get(SubclassAddsNewStaticField.class.getName());
 		assertThat(newClass.getSuperclass().getFields().length, is(1));
 	}
@@ -36,16 +36,16 @@ public class JavassistTest {
 	@Test
 	public void testMakeClass() throws NotFoundException, IOException {
 		ClassPool classPoolOld = new ClassPool();
-		classPoolOld.appendClassPath(getArchive("japicmp-test-service-v1.jar").getFile().getAbsolutePath());
-		classPoolOld.appendClassPath(getArchive("japicmp-test-service-impl-v1.jar").getFile().getAbsolutePath());
+		classPoolOld.appendClassPath(getArchive("japicmp-test-service-v1.jar").getFile().get().getAbsolutePath());
+		classPoolOld.appendClassPath(getArchive("japicmp-test-service-impl-v1.jar").getFile().get().getAbsolutePath());
 		classPoolOld.appendSystemPath();
-		List<CtClass> ctClasses = loadClasses(getArchive("japicmp-test-service-impl-v1.jar").getFile(), classPoolOld);
+		List<CtClass> ctClasses = loadClasses(getArchive("japicmp-test-service-impl-v1.jar").getFile().get(), classPoolOld);
 		assertThat(ctClasses.get(0).getSuperclass().getFields().length, is(1));
 		ClassPool classPoolNew = new ClassPool();
-		classPoolNew.appendClassPath(getArchive("japicmp-test-service-v2.jar").getFile().getAbsolutePath());
-		classPoolNew.appendClassPath(getArchive("japicmp-test-service-impl-v2.jar").getFile().getAbsolutePath());
+		classPoolNew.appendClassPath(getArchive("japicmp-test-service-v2.jar").getFile().get().getAbsolutePath());
+		classPoolNew.appendClassPath(getArchive("japicmp-test-service-impl-v2.jar").getFile().get().getAbsolutePath());
 		classPoolNew.appendSystemPath();
-		ctClasses = loadClasses(getArchive("japicmp-test-service-impl-v2.jar").getFile(), classPoolNew);
+		ctClasses = loadClasses(getArchive("japicmp-test-service-impl-v2.jar").getFile().get(), classPoolNew);
 		assertThat(ctClasses.get(0).getSuperclass().getFields().length, is(1));
 	}
 

--- a/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/src/test/java/japicmp/test/service/util/Helper.java
+++ b/japicmp-testbase/japicmp-test-service-impl-base/japicmp-test-service-test/src/test/java/japicmp/test/service/util/Helper.java
@@ -190,8 +190,8 @@ public class Helper {
 
 	public static List<String> createClassPath(String version) {
 		List<String> classPath = new ArrayList<>();
-		classPath.add(getArchive("japicmp-test-service-" + version + ".jar").getFile().getAbsolutePath());
-		classPath.add(getArchive("japicmp-test-service-impl-" + version + ".jar").getFile().getAbsolutePath());
+		classPath.add(getArchive("japicmp-test-service-" + version + ".jar").getFile().get().getAbsolutePath());
+		classPath.add(getArchive("japicmp-test-service-impl-" + version + ".jar").getFile().get().getAbsolutePath());
 		return classPath;
 	}
 }

--- a/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/SyntheticAttributeTest.java
+++ b/japicmp-testbase/japicmp-test/src/test/java/japicmp/test/SyntheticAttributeTest.java
@@ -54,7 +54,7 @@ public class SyntheticAttributeTest {
 	private JApiCmpArchive instrumentClass(JApiCmpArchive archive) throws IOException, CannotCompileException, NotFoundException {
 		ClassPool classPool = ClassPool.getDefault();
 		String path = Paths.get(System.getProperty("user.dir"), "target", "japicmp-test-v2-instrumented.jar").toString();
-		try (ZipFile zipFile = new ZipFile(archive.getFile()); ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(path))) {
+		try (ZipFile zipFile = new ZipFile(archive.getFile().get()); ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(path))) {
 			Enumeration<? extends ZipEntry> entries = zipFile.entries();
 			while (entries.hasMoreElements()) {
 				ZipEntry zipEntry = entries.nextElement();

--- a/japicmp/src/main/java/japicmp/cmp/JApiCmpArchive.java
+++ b/japicmp/src/main/java/japicmp/cmp/JApiCmpArchive.java
@@ -3,6 +3,7 @@ package japicmp.cmp;
 import japicmp.versioning.Version;
 
 import java.io.File;
+import java.util.Optional;
 
 public class JApiCmpArchive {
 	private File file;
@@ -21,20 +22,20 @@ public class JApiCmpArchive {
         this.name = name;
     }
 
-	public File getFile() {
-		return file;
+	public Optional<File> getFile() {
+		return Optional.ofNullable(file);
 	}
 
 	public Version getVersion() {
 		return version;
 	}
 
-	public byte[] getBytes() {
-		return bytes;
+	public Optional<byte[]> getBytes() {
+		return Optional.ofNullable(bytes);
 	}
 
-	public String getName() {
-		return name;
+	public Optional<String> getName() {
+		return Optional.ofNullable(name);
 	}
 
 	@Override

--- a/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
+++ b/japicmp/src/main/java/japicmp/cmp/JarArchiveComparator.java
@@ -220,8 +220,8 @@ public class JarArchiveComparator {
 	}
 
 	private Stream<CtClass> toCtClassStream(JApiCmpArchive archive, ReducibleClassPool classPool) {
-		if (archive.getFile() != null) {
-			try (JarFile jarFile = new JarFile(archive.getFile())) {
+		if (archive.getFile().isPresent()) {
+			try (JarFile jarFile = new JarFile(archive.getFile().get())) {
 				return jarFile.stream()
 					.map(jarEntry -> ctClass(classPool, jarFile, jarEntry))
 					.filter(Objects::nonNull)
@@ -229,7 +229,7 @@ public class JarArchiveComparator {
 			} catch (IOException e) {
 				throw new JApiCmpException(Reason.IoException, "Failed to load archive from file: " + e.getMessage(), e);
 			}
-		} else if (archive.getBytes() != null) {
+		} else if (archive.getBytes().isPresent()) {
 			return bytesToCtClasses(archive, classPool);
 		} else {
 			throw new JApiCmpException(Reason.IllegalArgument, JApiCmpArchive.class.getSimpleName() + " has no file and no bytes: " + archive);
@@ -238,7 +238,7 @@ public class JarArchiveComparator {
 
 	private static Stream<CtClass> bytesToCtClasses(JApiCmpArchive archive, ReducibleClassPool classPool) {
 		List<CtClass> ctClasses = new ArrayList<>();
-		try (JarInputStream jarInputStream = new JarInputStream(new ByteArrayInputStream(archive.getBytes()))) {
+		try (JarInputStream jarInputStream = new JarInputStream(new ByteArrayInputStream(archive.getBytes().get()))) {
 			JarEntry nextJarEntry = jarInputStream.getNextJarEntry();
 			while (nextJarEntry != null) {
 				if (!nextJarEntry.isDirectory() && nextJarEntry.getName().endsWith(".class")) {

--- a/japicmp/src/main/java/japicmp/config/Options.java
+++ b/japicmp/src/main/java/japicmp/config/Options.java
@@ -105,23 +105,29 @@ public class Options {
 	}
 
 	private static void verifyExisting(JApiCmpArchive jApiCmpArchive) {
-		if (!jApiCmpArchive.getFile().exists()) {
-			throw JApiCmpException.cliError("File '%s' does not exist.", jApiCmpArchive.getFile().getAbsolutePath());
+		if (!jApiCmpArchive.getFile().isPresent()) return;
+		File f = jApiCmpArchive.getFile().get();
+		if (!f.exists()) {
+			throw JApiCmpException.cliError("File '%s' does not exist.", f.getAbsolutePath());
 		}
 	}
 
 	private static void verifyCanRead(JApiCmpArchive jApiCmpArchive) {
-		if (!jApiCmpArchive.getFile().canRead()) {
-			throw JApiCmpException.cliError("Cannot read file '%s'.", jApiCmpArchive.getFile().getAbsolutePath());
+		if (!jApiCmpArchive.getFile().isPresent()) return;
+		File f = jApiCmpArchive.getFile().get();
+		if (!f.canRead()) {
+			throw JApiCmpException.cliError("Cannot read file '%s'.", f.getAbsolutePath());
 		}
 	}
 
 	private static void verifyJarArchive(JApiCmpArchive jApiCmpArchive) {
+		if (!jApiCmpArchive.getFile().isPresent()) return;
+		File f = jApiCmpArchive.getFile().get();
 		JarFile jarFile = null;
 		try {
-			jarFile = new JarFile(jApiCmpArchive.getFile());
+			jarFile = new JarFile(f);
 		} catch (IOException e) {
-			throw JApiCmpException.cliError("File '%s' could not be opened as a jar file: %s", jApiCmpArchive.getFile().getAbsolutePath(), e.getMessage(), e);
+			throw JApiCmpException.cliError("File '%s' could not be opened as a jar file: %s", f.getAbsolutePath(), e.getMessage(), e);
 		} finally {
 			if (jarFile != null) {
 				try {
@@ -332,16 +338,16 @@ public class Options {
 		List<String> paths = new ArrayList<>(archives.size());
 		for (JApiCmpArchive archive : archives) {
 			if (this.reportOnlyFilename) {
-				if (archive.getFile() != null) {
-					paths.add(archive.getFile().getName());
+				if (archive.getFile().isPresent()) {
+					paths.add(archive.getFile().get().getName());
 				} else {
-					paths.add(archive.getName());
+					paths.add(archive.getName().orElse(null));
 				}
 			} else {
-				if (archive.getFile() != null) {
-					paths.add(archive.getFile().getAbsolutePath());
+				if (archive.getFile().isPresent()) {
+					paths.add(archive.getFile().get().getAbsolutePath());
 				} else {
-					paths.add(archive.getName());
+					paths.add(archive.getName().orElse(null));
 				}
 			}
 		}

--- a/japicmp/src/main/java/japicmp/output/markdown/MarkdownOutputGenerator.java
+++ b/japicmp/src/main/java/japicmp/output/markdown/MarkdownOutputGenerator.java
@@ -19,6 +19,7 @@ import japicmp.model.JApiJavaObjectSerializationCompatibility.JApiJavaObjectSeri
 import japicmp.output.*;
 import japicmp.output.markdown.config.MarkdownOptions;
 import japicmp.output.semver.SemverOut;
+import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -582,7 +583,9 @@ public class MarkdownOutputGenerator extends OutputGenerator<String> {
 
 	String renderSimpleArchiveName(JApiCmpArchive archive) {
 		final String version = archive.getVersion().getStringVersion();
-		String name = archive.getFile().getName();
+		String name = archive.getFile()
+			.map(File::getName)
+			.orElseGet(() -> archive.getName().orElse(""));
 		// Drop version from archive name
 		if (version != null && name.contains(version)) {
 			name = name.replace(version, EMPTY);

--- a/japicmp/src/main/java/japicmp/util/FileHelper.java
+++ b/japicmp/src/main/java/japicmp/util/FileHelper.java
@@ -17,7 +17,7 @@ public class FileHelper {
 	public static List<File> toFileList(List<JApiCmpArchive> archives) {
 		List<File> files = new ArrayList<>(archives.size());
 		for (JApiCmpArchive archive : archives) {
-			files.add(archive.getFile());
+			archive.getFile().ifPresent(files::add);
 		}
 		return files;
 	}

--- a/japicmp/src/test/java/japicmp/output/markdown/MarkdownOutputGeneratorTest.java
+++ b/japicmp/src/test/java/japicmp/output/markdown/MarkdownOutputGeneratorTest.java
@@ -291,4 +291,13 @@ class MarkdownOutputGeneratorTest {
 		assertThat(generated, containsString(format(MSG.compatibilitySource, MSG.unchecked)));
 		assertThat(generated, containsString(format(MSG.compatibilitySerialization, MSG.checked)));
 	}
+
+	@Test
+	void testRenderSimpleArchiveNameForByteBasedArchive() {
+		// Regression test for issue #516: byte-based archive (no File) must not throw NPE
+		JApiCmpArchive archive = new JApiCmpArchive(new byte[0], "1.0.0", "my-library-1.0.0.jar");
+		MarkdownOutputGenerator generator = new MarkdownOutputGenerator(Options.newDefault(), emptyList());
+		String name = generator.renderSimpleArchiveName(archive);
+		Assertions.assertEquals("my-library", name);
+	}
 }

--- a/japicmp/src/test/java/japicmp/util/FileHelperTest.java
+++ b/japicmp/src/test/java/japicmp/util/FileHelperTest.java
@@ -31,17 +31,17 @@ class FileHelperTest {
 				.createFileList("projecta-11.22.33-SNAPSHOT.jar;projectb-44.55.66.jar;projectd.jar");
 		MatcherAssert.assertThat(archives.size(), is(3));
 
-		MatcherAssert.assertThat(archives.get(0).getFile(), is(new File("projecta-11.22.33-SNAPSHOT.jar")));
+		MatcherAssert.assertThat(archives.get(0).getFile().get(), is(new File("projecta-11.22.33-SNAPSHOT.jar")));
 		MatcherAssert.assertThat(archives.get(0).getVersion().getSemanticVersion().get(),
 				is(new SemanticVersion(11, 22, 33)));
 		MatcherAssert.assertThat(archives.get(0).getVersion().getStringVersion(), is("11.22.33-SNAPSHOT"));
 
-		MatcherAssert.assertThat(archives.get(1).getFile(), is(new File("projectb-44.55.66.jar")));
+		MatcherAssert.assertThat(archives.get(1).getFile().get(), is(new File("projectb-44.55.66.jar")));
 		MatcherAssert.assertThat(archives.get(1).getVersion().getSemanticVersion().get(),
 				is(new SemanticVersion(44, 55, 66)));
 		MatcherAssert.assertThat(archives.get(1).getVersion().getStringVersion(), is("44.55.66"));
 
-		MatcherAssert.assertThat(archives.get(2).getFile(), is(new File("projectd.jar")));
+		MatcherAssert.assertThat(archives.get(2).getFile().get(), is(new File("projectd.jar")));
 		MatcherAssert.assertThat(archives.get(2).getVersion().getSemanticVersion().isPresent(), is(false));
 		MatcherAssert.assertThat(archives.get(2).getVersion().getStringVersion(), is("n.a."));
 	}


### PR DESCRIPTION
Return Optional<File>, Optional<byte[]>, and Optional<String> from
JApiCmpArchive.getFile(), getBytes(), and getName() to make the
nullable contract explicit. Update all callers accordingly and add a
regression test that covers the byte-based archive path in
renderSimpleArchiveName().

https://claude.ai/code/session_015JXYU1LJZMCq9ot45XWywE